### PR TITLE
function literal implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ def filter(list, fn)
   return ret
 end
 
-list = [42, null, 3.14, "String", 0..10, ['hello']]
+## A list of range literal, first class functions and more types.
+list = [42, null, 0..10, function() print('hello') end, [3.14]]
 nums = filter(list, is_num)
-print(get_max(nums))
+print("Max is", get_max(nums))
 
 ```
 

--- a/SConstruct
+++ b/SConstruct
@@ -2,10 +2,11 @@
 import os, subprocess, sys
 
 def get_variant_dir(env):
-	ret = 'build/' + env['platform'] + '/' + env['target'];
+	ret = 'build/' + env['platform'] + '/' + env['target'] + '/'
 	if env['platform'] == 'windows':
-		return ret + '/' + env['bits']
+		return ret + env['bits'] + '/'
 	return ret
+env.get_variant_dir = get_variant_dir
 
 opts = Variables([], ARGUMENTS)
 ## Define our options

--- a/configure.py
+++ b/configure.py
@@ -1,7 +1,11 @@
 import sys, os
 
+def main():
+	generate_files()
+
+
 def log(*msg):
-	print("[autotool.py]", end='')
+	print("[ms:configure.py]", end='')
 	for _msg in msg:
 		print(' ' + _msg, end='')
 	print()
@@ -22,4 +26,4 @@ def generate_files():
 	return ec
 	
 if __name__ == '__main__':
-	generate_files()
+	main()

--- a/src/opcodes.h
+++ b/src/opcodes.h
@@ -51,26 +51,28 @@ OPCODE(PUSH_LOCAL_7, 0, 1)
 OPCODE(PUSH_LOCAL_8, 0, 1)
 OPCODE(PUSH_LOCAL_N, 2, 1)
 
-// Pop the stack top value and store to another stack local index.
+// Store the stack top value to another stack local index and don't pop since
+// it's the result of the assignment.
 // params: STORE_LOCAL_N -> 2 bytes (uint16_t) count value.
-OPCODE(STORE_LOCAL_0, 0, -1)
-OPCODE(STORE_LOCAL_1, 0, -1)
-OPCODE(STORE_LOCAL_2, 0, -1)
-OPCODE(STORE_LOCAL_3, 0, -1)
-OPCODE(STORE_LOCAL_4, 0, -1)
-OPCODE(STORE_LOCAL_5, 0, -1)
-OPCODE(STORE_LOCAL_6, 0, -1)
-OPCODE(STORE_LOCAL_7, 0, -1)
-OPCODE(STORE_LOCAL_8, 0, -1)
-OPCODE(STORE_LOCAL_N, 2, -1)
+OPCODE(STORE_LOCAL_0, 0, 0)
+OPCODE(STORE_LOCAL_1, 0, 0)
+OPCODE(STORE_LOCAL_2, 0, 0)
+OPCODE(STORE_LOCAL_3, 0, 0)
+OPCODE(STORE_LOCAL_4, 0, 0)
+OPCODE(STORE_LOCAL_5, 0, 0)
+OPCODE(STORE_LOCAL_6, 0, 0)
+OPCODE(STORE_LOCAL_7, 0, 0)
+OPCODE(STORE_LOCAL_8, 0, 0)
+OPCODE(STORE_LOCAL_N, 2, 0)
 
 // Push the script global value on the stack.
 // params: 2 bytes (uint16_t) index.
 OPCODE(PUSH_GLOBAL, 2, 1)
 
-// Pop and store the value to script's global.
+// Store the stack top value to a global value and don't pop since it's the
+// result of the assignment.
 // params: 2 bytes (uint16_t) index.
-OPCODE(STORE_GLOBAL, 2, -1)
+OPCODE(STORE_GLOBAL, 2, 0)
 
 // Push the script's function on the stack. It could later be called. But a
 // function can't be stored i.e. can't assign a function with something else.

--- a/src/var.c
+++ b/src/var.c
@@ -66,6 +66,7 @@ List* newList(MSVM* vm, uint32_t size) {
     varBufferFill(&list->elements, vm, VAR_NULL, size);
     list->elements.count = 0;
   }
+  return list;
 }
 
 Range* newRange(MSVM* vm, double from, double to) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -128,7 +128,7 @@ MSInterpretResult vmRunScript(MSVM* vm, Script* _script) {
 #define PUSH(value) (*vm->sp++ = (value))
 #define POP()       (*(--vm->sp))
 #define DROP()      (--vm->sp)
-#define PEEK()      (vm->sp - 1)
+#define PEEK()      (*(vm->sp - 1))
 #define READ_BYTE() (*ip++)
 #define READ_SHORT() (ip+=2, (uint16_t)((ip[-2] << 8) | ip[-1]))
 
@@ -263,13 +263,13 @@ MSInterpretResult vmRunScript(MSVM* vm, Script* _script) {
     OPCODE(STORE_LOCAL_8):
     {
       int index = (int)(instruction - OP_STORE_LOCAL_0);
-      rbp[index] = POP();
+      rbp[index] = PEEK();
       DISPATCH();
     }
     OPCODE(STORE_LOCAL_N):
     {
       int index = READ_SHORT();
-      rbp[index] = POP();
+      rbp[index] = PEEK();
       DISPATCH();
     }
 
@@ -285,7 +285,7 @@ MSInterpretResult vmRunScript(MSVM* vm, Script* _script) {
     {
       int index = READ_SHORT();
       ASSERT(index < script->globals.count, OOPS);
-      script->globals.data[index] = POP();
+      script->globals.data[index] = PEEK();
       DISPATCH();
     }
 


### PR DESCRIPTION
These are now valid syntaxes
```ruby
fn = function()
  print('hello')
end

function(val)
  print('val =', val)
end (3.14)  ##< This will call the literal function.

do_something(function() print('hello') end)

list = [42, function() print('hello') end, null]
```