### PR TITLE
Fix minor typos, while reading codebase

### DIFF
--- a/cli/TODO.txt
+++ b/cli/TODO.txt
@@ -43,7 +43,7 @@
 
 // Add more.
 - Single header for embedding (script in pk, require file IO).
-[ ] Compilte core methods.
+[ ] Complete core methods.
 [ ] Complete var methods.
 [ ] Complete core functions.
 [ ] Complete builtin operators.

--- a/cli/main.c
+++ b/cli/main.c
@@ -9,7 +9,7 @@
 
 #include <pocketlang.h>
 
-// FIXME: everything below here is temproary and for testing.
+// FIXME: everything below here is temporary and for testing.
 
 void registerModules(PKVM* vm);
 
@@ -195,7 +195,7 @@ int main(int argc, char** argv) {
     do {
       printf(">>> ");
       PkStringPtr line = { read_line(), onResultDone, (void*)true };
-      // TODO: if line is empty continue.
+      // TODO: if line is empty, continue.
 
       result = pkCompileModule(vm, module, line, &options);
       if (result != PK_RESULT_SUCCESS) continue;

--- a/src/common.h
+++ b/src/common.h
@@ -8,7 +8,7 @@
 
 #include "include/pocketlang.h"
 
-// Commenly used c standard headers across the sources. Don't include any
+// Commonly used c standard headers across the sources. Don't include any
 // headers that are specific to a single source here, instead include them in
 // their source files explicitly (canno't be implicitly included by another
 // header). And don't include any C standard headers in any of the pocketlang

--- a/src/common.h
+++ b/src/common.h
@@ -10,7 +10,7 @@
 
 // Commonly used c standard headers across the sources. Don't include any
 // headers that are specific to a single source here, instead include them in
-// their source files explicitly (canno't be implicitly included by another
+// their source files explicitly (can not be implicitly included by another
 // header). And don't include any C standard headers in any of the pocketlang
 // headers.
 #include <assert.h>


### PR DESCRIPTION
While trying to just skim through the code base, spotting some minor typos. Please, ignore this if it doesn't make sense.