### PR TITLE
Set pointer to first byte of memory block when `realloc()`'d

### DIFF
--- a/cli/repl.c
+++ b/cli/repl.c
@@ -4,7 +4,7 @@
  */
 
 
-// The REPL (Read Evaluvate Print Loop) implementation.
+// The REPL (Read Evaluate Print Loop) implementation.
 // https://en.wikipedia.org/wiki/Read–eval–print_loop.
 
 #include "common.h"

--- a/cli/utils.c
+++ b/cli/utils.c
@@ -34,7 +34,7 @@ void byteBufferInit(ByteBuffer* buffer) {
 }
 
 void byteBufferClear(ByteBuffer* buffer) {
-  realloc(buffer->data, 0);
+  buffer->data = realloc(buffer->data, 0);
   buffer->data = NULL;
   buffer->count = 0;
   buffer->capacity = 0;

--- a/cli/utils.h
+++ b/cli/utils.h
@@ -19,7 +19,7 @@ typedef struct {
 // Initialize a new buffer int instance. 
 void byteBufferInit(ByteBuffer* buffer);
 
-// Clears the allocated elementes from the VM's realloc function. 
+// Clears the allocated elements from the VM's realloc function.
 void byteBufferClear(ByteBuffer* buffer);
 
 // Ensure the capacity is greater than [size], if not resize. 

--- a/src/pk_common.h
+++ b/src/pk_common.h
@@ -37,7 +37,7 @@
 // Set this to dump stack frame before executing the next instruction.
 #define DEBUG_DUMP_CALL_STACK 0
 
-// Nan-Tagging could be disable for debugging/portability purposes. see "var.h"
+// Nan-Tagging could be disable for debugging/portability purposes. See "var.h"
 // header for more information on Nan-tagging.
 #define VAR_NAN_TAGGING 1
 

--- a/src/pk_compiler.h
+++ b/src/pk_compiler.h
@@ -15,12 +15,12 @@ typedef enum {
   #undef OPCODE
 } Opcode;
 
-// Pocketlang compiler is a single pass compiler, which means it doesn't go
-// throught the basic compilation pipline such as lexing, parsing (AST),
-// analyzing, intermediate codegeneration, and target codegeneration one by one
-// instead it'll generate the target code as it reads the source (directly from
-// lexing to codegen). Despite it's faster than multipass compilers, we're
-// restricted syntax-wise and from compiletime optimizations, yet we support
+// Pocketlang compiler is a one pass/single pass compiler, which means it
+// doesn't go through the basic compilation pipeline such as lexing, parsing
+// (AST), analyzing, intermediate code generation, and target codegeneration
+// one by one. Instead it'll generate the target code as it reads the source
+// (directly from lexing to codegen). Despite it faster than multipass compilers,
+// we're restricted syntax-wise and from compile-time optimizations, yet we support
 // "forward names" to call functions before they defined (unlike C/Python).
 typedef struct Compiler Compiler;
 

--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -57,7 +57,7 @@ PkHandle* pkGetFunction(PKVM* vm, PkHandle* module,
   // for 'global_names' refactor them from VarBuffer to GlobalVarBuffer where
   // GlobalVar is struct { const char* name, Var value };
   // 
-  // "nicreasing-name" order index buffer:
+  // "increasing-name" order index buffer:
   //   A buffer of int where each is an index in the function buffer and each
   //   points to different functions in an "increasing-name" (could be hash
   //   value) order. If we have more than some threshold number of function
@@ -72,15 +72,15 @@ PkHandle* pkGetFunction(PKVM* vm, PkHandle* module,
   return NULL;
 }
 
-// A convinent macro to get the nth (1 based) argument of the current function.
+// A convenient macro to get the nth (1 based) argument of the current function.
 #define ARG(n) (vm->fiber->ret[n])
 
-// Convinent macros to get the 1st, 2nd, 3rd arguments.
+// Convenient macros to get the 1st, 2nd, 3rd arguments.
 #define ARG1 ARG(1)
 #define ARG2 ARG(2)
 #define ARG3 ARG(3)
 
-// Evaluvates to the current function's argument count.
+// Evaluates to the current function's argument count.
 #define ARGC ((int)(vm->fiber->sp - vm->fiber->ret) - 1)
 
 // Set return value for the current native function and return.

--- a/src/pk_vm.c
+++ b/src/pk_vm.c
@@ -10,7 +10,7 @@
 #include "pk_utils.h"
 #include "pk_debug.h"
 
-// Evaluvated to true if a runtime error set on the current fiber.
+// Evaluated to "true" if a runtime error set on the current fiber.
 #define HAS_ERROR() (vm->fiber->error != NULL)
 
 /*****************************************************************************/


### PR DESCRIPTION
* While reading various files in the repo, just going ahead to clean up some typos (for clarity of text).

* When calling `realloc()`, let the pointer be returned to the first byte of the memory block after resize. Compiler warns against not doing this too.

* In addition, rename the file `uitls.c` to "`utils.c`" which seems to be the correct name in this case.

NOTE: I recompiled and tested the `./pocket` interpret and it still works as expected.