### PR TITLE
Fix #56: Implement the `cos()` and `tan()` math functions

### DIFF
--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -880,6 +880,26 @@ static void stdMathSine(PKVM* vm)) {
   RET(VAR_NUM(sin(rad)));
 }
 
+PK_DOC(
+  "cosine(rad:num) -> num\n"
+  "Return the cosine value of the argument [rad] which is an angle expressed "
+  "in radians.",
+static void stdMathCosine(PKVM* vm)) {
+  double rad;
+  if (!validateNumeric(vm, ARG(1), &rad, "Argument 1")) return;
+  RET(VAR_NUM(cos(rad)));
+}
+
+PK_DOC(
+  "tan(rad:num) -> num\n"
+  "Return the tangent value of the argument [rad] which is an angle expressed "
+  "in radians.",
+static void stdMathTangent(PKVM* vm)) {
+  double rad;
+  if (!validateNumeric(vm, ARG(1), &rad, "Argument 1")) return;
+  RET(VAR_NUM(tan(rad)));
+}
+
 /*****************************************************************************/
 /* CORE INITIALIZATION                                                       */
 /*****************************************************************************/
@@ -956,16 +976,18 @@ void initializeCore(PKVM* vm) {
 #endif
 
   Script* math = newModuleInternal(vm, "math");
-  moduleAddFunctionInternal(vm, math, "floor", stdMathFloor,  1);
-  moduleAddFunctionInternal(vm, math, "ceil",  stdMathCeil,   1);
-  moduleAddFunctionInternal(vm, math, "pow",   stdMathPow,    2);
-  moduleAddFunctionInternal(vm, math, "sqrt",  stdMathSqrt,   1);
-  moduleAddFunctionInternal(vm, math, "abs",   stdMathAbs,    1);
-  moduleAddFunctionInternal(vm, math, "sign",  stdMathSign,   1);
-  moduleAddFunctionInternal(vm, math, "hash",  stdMathHash,   1);
-  moduleAddFunctionInternal(vm, math, "sin",   stdMathSine,   1);
-  // TODO: add - cos, tan.
-  // low priority: sinh, cosh, tanh, asin, acos, atan.
+  moduleAddFunctionInternal(vm, math, "floor", stdMathFloor,   1);
+  moduleAddFunctionInternal(vm, math, "ceil",  stdMathCeil,    1);
+  moduleAddFunctionInternal(vm, math, "pow",   stdMathPow,     2);
+  moduleAddFunctionInternal(vm, math, "sqrt",  stdMathSqrt,    1);
+  moduleAddFunctionInternal(vm, math, "abs",   stdMathAbs,     1);
+  moduleAddFunctionInternal(vm, math, "sign",  stdMathSign,    1);
+  moduleAddFunctionInternal(vm, math, "hash",  stdMathHash,    1);
+  moduleAddFunctionInternal(vm, math, "sin",   stdMathSine,    1);
+  moduleAddFunctionInternal(vm, math, "cos",   stdMathCosine,  1);
+  moduleAddFunctionInternal(vm, math, "tan",   stdMathTangent, 1);
+
+  // TODO: low priority - sinh, cosh, tanh, asin, acos, atan.
 
   // Note that currently it's mutable (since it's a global variable, not
   // constant and pocketlang doesn't support constant) so the user shouldn't

--- a/tests/lang/core.pk
+++ b/tests/lang/core.pk
@@ -1,4 +1,3 @@
-
 ## Core builtin functions and attribute tests.
 
 assert(hex(12648430) == '0xc0ffee')
@@ -29,4 +28,18 @@ assert(print.name == "print")
 def fn(p1, p2, p3) end
 assert(fn.name == "fn")
 assert(fn.arity == 3)
+
+## Math functions
+from math import PI, sin, cos, tan, abs
+
+assert(sin(0) == 0)
+assert(sin(PI/2) == 1)
+
+threshold = 0.0000000000001
+
+assert(abs(cos(PI/3) - 0.5) < threshold )
+assert(abs(tan(PI/4) - 1.0) < threshold )
+for i in 0..1000
+  assert(abs(sin(i) / cos(i) - tan(i)) < threshold)
+end
 


### PR DESCRIPTION
I've also written tests in the corresponding test files, please have
a look. But on the command line (after compiling the source), do:

>>> from math import *
>>> print(cos(1))
[ results will be displayed here ]
>>> print(tan(1))
[ results will be displayed here ]

*Edit Fix: #56*