### PR TITLE
Fix #54: Add bitwise OR operator and make it available in PKVM

### DIFF
--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -1140,6 +1140,20 @@ Var varBitAnd(PKVM* vm, Var v1, Var v2) {
   return VAR_NULL;
 }
 
+Var varBitOr(PKVM* vm, Var v1, Var v2) {
+
+  int64_t i1, i2;
+  if (isInteger(v1, &i1)) {
+    if (validateInteger(vm, v2, &i2, "Right operand")) {
+      return VAR_NUM(i1 | i2);
+    }
+    return VAR_NULL;
+  }
+
+  UNSUPPORT_OPERAND_TYPES("|");
+  return VAR_NULL;
+}
+
 bool varGreater(Var v1, Var v2) {
   double d1, d2;
   if (isNumeric(v1, &d1) && isNumeric(v2, &d2)) {

--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -1145,7 +1145,7 @@ Var varBitOr(PKVM* vm, Var v1, Var v2) {
   int64_t i1, i2;
   if (isInteger(v1, &i1)) {
     if (validateInteger(vm, v2, &i2, "Right operand")) {
-      return VAR_NUM(i1 | i2);
+      return VAR_NUM((double)(i1 | i2));
     }
     return VAR_NULL;
   }

--- a/src/pk_core.h
+++ b/src/pk_core.h
@@ -37,6 +37,7 @@ Var varDivide(PKVM* vm, Var v1, Var v2);   // Returns v1 / v2.
 Var varModulo(PKVM* vm, Var v1, Var v2);   // Returns v1 % v2.
 
 Var varBitAnd(PKVM* vm, Var v1, Var v2);   // Returns v1 & v2.
+Var varBitOr(PKVM* vm, Var v1, Var v2);    // Returns v1 | v2.
 
 bool varGreater(Var v1, Var v2); // Returns v1 > v2.
 bool varLesser(Var v1, Var v2);  // Returns v1 < v2.

--- a/src/pk_vm.c
+++ b/src/pk_vm.c
@@ -1247,7 +1247,6 @@ static PkResult runFiber(PKVM* vm, Fiber* fiber) {
       // Don't pop yet, we need the reference for gc.
       Var r = PEEK(-1), l = PEEK(-2);
 
-      // Result is in base 10 (decimal)
       Var result = varBitOr(vm, l, r);
       DROP(); DROP(); // r, l
       PUSH(result);

--- a/src/pk_vm.c
+++ b/src/pk_vm.c
@@ -1151,7 +1151,7 @@ static PkResult runFiber(PKVM* vm, Fiber* fiber) {
     {
       Var num = POP();
       if (!IS_NUM(num)) {
-        RUNTIME_ERROR(newString(vm, "Cannot negate a non numeric value."));
+        RUNTIME_ERROR(newString(vm, "Can not negate a non numeric value."));
       }
       PUSH(VAR_NUM(-AS_NUM(num)));
       DISPATCH();
@@ -1174,9 +1174,9 @@ static PkResult runFiber(PKVM* vm, Fiber* fiber) {
     {
       // Don't pop yet, we need the reference for gc.
       Var r = PEEK(-1), l = PEEK(-2);
-      Var value = varAdd(vm, l, r);
+      Var result = varAdd(vm, l, r);
       DROP(); DROP(); // r, l
-      PUSH(value);
+      PUSH(result);
 
       CHECK_ERROR();
       DISPATCH();
@@ -1186,9 +1186,9 @@ static PkResult runFiber(PKVM* vm, Fiber* fiber) {
     {
       // Don't pop yet, we need the reference for gc.
       Var r = PEEK(-1), l = PEEK(-2);
-      Var value = varSubtract(vm, l, r);
+      Var result = varSubtract(vm, l, r);
       DROP(); DROP(); // r, l
-      PUSH(value);
+      PUSH(result);
 
       CHECK_ERROR();
       DISPATCH();
@@ -1198,9 +1198,9 @@ static PkResult runFiber(PKVM* vm, Fiber* fiber) {
     {
       // Don't pop yet, we need the reference for gc.
       Var r = PEEK(-1), l = PEEK(-2);
-      Var value = varMultiply(vm, l, r);
+      Var result = varMultiply(vm, l, r);
       DROP(); DROP(); // r, l
-      PUSH(value);
+      PUSH(result);
 
       CHECK_ERROR();
       DISPATCH();
@@ -1210,9 +1210,9 @@ static PkResult runFiber(PKVM* vm, Fiber* fiber) {
     {
       // Don't pop yet, we need the reference for gc.
       Var r = PEEK(-1), l = PEEK(-2);
-      Var value = varDivide(vm, l, r);
+      Var result = varDivide(vm, l, r);
       DROP(); DROP(); // r, l
-      PUSH(value);
+      PUSH(result);
 
       CHECK_ERROR();
       DISPATCH();
@@ -1222,9 +1222,9 @@ static PkResult runFiber(PKVM* vm, Fiber* fiber) {
     {
       // Don't pop yet, we need the reference for gc.
       Var r = PEEK(-1), l = PEEK(-2);
-      Var value = varModulo(vm, l, r);
+      Var result = varModulo(vm, l, r);
       DROP(); DROP(); // r, l
-      PUSH(value);
+      PUSH(result);
 
       CHECK_ERROR();
       DISPATCH();
@@ -1234,15 +1234,28 @@ static PkResult runFiber(PKVM* vm, Fiber* fiber) {
     {
       // Don't pop yet, we need the reference for gc.
       Var r = PEEK(-1), l = PEEK(-2);
-      Var value = varBitAnd(vm, l, r);
+      Var result = varBitAnd(vm, l, r);
       DROP(); DROP(); // r, l
-      PUSH(value);
+      PUSH(result);
 
       CHECK_ERROR();
       DISPATCH();
     }
 
     OPCODE(BIT_OR):
+    {
+      // Don't pop yet, we need the reference for gc.
+      Var r = PEEK(-1), l = PEEK(-2);
+
+      // Result is in base 10 (decimal)
+      Var result = varBitOr(vm, l, r);
+      DROP(); DROP(); // r, l
+      PUSH(result);
+
+      CHECK_ERROR();
+      DISPATCH();
+    }
+
     OPCODE(BIT_XOR):
     OPCODE(BIT_LSHIFT):
     OPCODE(BIT_RSHIFT):

--- a/tests/lang/basics.pk
+++ b/tests/lang/basics.pk
@@ -36,4 +36,15 @@ m = {}
 m['m'] = m
 assert(to_string(m) == '{"m":{...}}')
 
+# Bitwise operation tests
+assert((1 | 1) == 1)
+assert((1 | 4) == 5)
+assert((3 | 5) == 7)
+
+assert((1 & 1) == 1)
+assert((1 & 2) == 0)
+assert((4 & 7) == 4)
+
+# If got here with no errors, then all test passed
+print('All tests PASSED ✅')
 

--- a/tests/lang/basics.pk
+++ b/tests/lang/basics.pk
@@ -46,5 +46,5 @@ assert((1 & 2) == 0)
 assert((4 & 7) == 4)
 
 # If we got here with no errors, then all test passed
-print('All tests PASSED ✅')
+print('All tests PASSED (100%)')
 

--- a/tests/lang/basics.pk
+++ b/tests/lang/basics.pk
@@ -45,6 +45,6 @@ assert((1 & 1) == 1)
 assert((1 & 2) == 0)
 assert((4 & 7) == 4)
 
-# If got here with no errors, then all test passed
+# If we got here with no errors, then all test passed
 print('All tests PASSED ✅')
 

--- a/tests/lang/core.pk
+++ b/tests/lang/core.pk
@@ -44,5 +44,5 @@ for i in 0..1000
 end
 
 # If we got here with no errors, then all test passed
-print('All tests PASSED ✅')
+print('All tests PASSED (100%)')
 

--- a/tests/lang/core.pk
+++ b/tests/lang/core.pk
@@ -43,6 +43,6 @@ for i in 0..1000
   assert(abs(sin(i) / cos(i) - tan(i)) < threshold)
 end
 
-# If got here with no errors, then all test passed
+# If we got here with no errors, then all test passed
 print('All tests PASSED ✅')
 

--- a/tests/lang/core.pk
+++ b/tests/lang/core.pk
@@ -43,3 +43,6 @@ for i in 0..1000
   assert(abs(sin(i) / cos(i) - tan(i)) < threshold)
 end
 
+# If got here with no errors, then all test passed
+print('All tests PASSED ✅')
+


### PR DESCRIPTION
Like the bitwise AND, this is an implementation for pocketlang to support the bitwise OR operation. In addition, updated "value" -> "result" in other operation to correctly reflect the container's purpose. It's indeed the result after the operation, which is a value too.

In addition, add tests for bitwise AND (&) and bitwise OR (|). Add a print statement with message that all tests passed with no errors.

*Edit Fix: #54*