### PR TITLE
Add support for bitwise XOR, LSHIFT and RSHIFT operators

### DIFF
--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -1024,11 +1024,13 @@ void initializeCore(PKVM* vm) {
   VM_SET_ERROR(vm, stringFormat(vm, "Unsupported operand types for "   \
     "operator '" op "' $ and $", varTypeName(v1), varTypeName(v2)))
 
-Var varAdd(PKVM* vm, Var v1, Var v2) {
+#define PK_RIGHT_OP "Right operand"
 
+Var varAdd(PKVM* vm, Var v1, Var v2) {
   double d1, d2;
+
   if (isNumeric(v1, &d1)) {
-    if (validateNumeric(vm, v2, &d2, "Right operand")) {
+    if (validateNumeric(vm, v2, &d2, PK_RIGHT_OP)) {
       return VAR_NUM(d1 + d2);
     }
     return VAR_NULL;
@@ -1069,8 +1071,9 @@ Var varAdd(PKVM* vm, Var v1, Var v2) {
 
 Var varSubtract(PKVM* vm, Var v1, Var v2) {
   double d1, d2;
+
   if (isNumeric(v1, &d1)) {
-    if (validateNumeric(vm, v2, &d2, "Right operand")) {
+    if (validateNumeric(vm, v2, &d2, PK_RIGHT_OP)) {
       return VAR_NUM(d1 - d2);
     }
     return VAR_NULL;
@@ -1081,10 +1084,10 @@ Var varSubtract(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varMultiply(PKVM* vm, Var v1, Var v2) {
-
   double d1, d2;
+
   if (isNumeric(v1, &d1)) {
-    if (validateNumeric(vm, v2, &d2, "Right operand")) {
+    if (validateNumeric(vm, v2, &d2, PK_RIGHT_OP)) {
       return VAR_NUM(d1 * d2);
     }
     return VAR_NULL;
@@ -1096,8 +1099,9 @@ Var varMultiply(PKVM* vm, Var v1, Var v2) {
 
 Var varDivide(PKVM* vm, Var v1, Var v2) {
   double d1, d2;
+
   if (isNumeric(v1, &d1)) {
-    if (validateNumeric(vm, v2, &d2, "Right operand")) {
+    if (validateNumeric(vm, v2, &d2, PK_RIGHT_OP)) {
       return VAR_NUM(d1 / d2);
     }
     return VAR_NULL;
@@ -1108,10 +1112,10 @@ Var varDivide(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varModulo(PKVM* vm, Var v1, Var v2) {
-
   double d1, d2;
+
   if (isNumeric(v1, &d1)) {
-    if (validateNumeric(vm, v2, &d2, "Right operand")) {
+    if (validateNumeric(vm, v2, &d2, PK_RIGHT_OP)) {
       return VAR_NUM(fmod(d1, d2));
     }
     return VAR_NULL;
@@ -1127,10 +1131,10 @@ Var varModulo(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varBitAnd(PKVM* vm, Var v1, Var v2) {
-
   int64_t i1, i2;
+
   if (isInteger(v1, &i1)) {
-    if (validateInteger(vm, v2, &i2, "Right operand")) {
+    if (validateInteger(vm, v2, &i2, PK_RIGHT_OP)) {
       return VAR_NUM((double)(i1 & i2));
     }
     return VAR_NULL;
@@ -1141,10 +1145,10 @@ Var varBitAnd(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varBitOr(PKVM* vm, Var v1, Var v2) {
-
   int64_t i1, i2;
+
   if (isInteger(v1, &i1)) {
-    if (validateInteger(vm, v2, &i2, "Right operand")) {
+    if (validateInteger(vm, v2, &i2, PK_RIGHT_OP)) {
       return VAR_NUM((double)(i1 | i2));
     }
     return VAR_NULL;
@@ -1154,8 +1158,51 @@ Var varBitOr(PKVM* vm, Var v1, Var v2) {
   return VAR_NULL;
 }
 
+Var varBitXor(PKVM* vm, Var v1, Var v2) {
+  int64_t i1, i2;
+
+  if (isInteger(v1, &i1)) {
+    if (validateInteger(vm, v2, &i2, PK_RIGHT_OP)) {
+      return VAR_NUM((double)(i1 ^ i2));
+    }
+    return VAR_NULL;
+  } 
+
+  UNSUPPORT_OPERAND_TYPES("^");
+  return VAR_NULL;
+}
+
+Var varBitLshift(PKVM* vm, Var v1, Var v2) {
+  int64_t i1, i2;
+
+  if (isInteger(v1, &i1)) {
+    if (validateInteger(vm, v2, &i2, PK_RIGHT_OP)) {
+      return VAR_NUM((double)(i1 << i2));
+    }
+    return VAR_NULL;
+  }
+
+  UNSUPPORT_OPERAND_TYPES("<<");
+  return VAR_NULL;
+}
+
+Var varBitRshift(PKVM* vm, Var v1, Var v2) {
+  int64_t i1, i2;
+
+  if (isInteger(v1, &i1)) {
+    if (validateInteger(vm, v2, &i2, PK_RIGHT_OP)) {
+      return VAR_NUM((double)(i1 >> i2));
+    }
+    return VAR_NULL;
+  }
+
+  UNSUPPORT_OPERAND_TYPES(">>");
+  return VAR_NULL;
+}
+
 bool varGreater(Var v1, Var v2) {
   double d1, d2;
+
   if (isNumeric(v1, &d1) && isNumeric(v2, &d2)) {
     return d1 > d2;
   }
@@ -1166,6 +1213,7 @@ bool varGreater(Var v1, Var v2) {
 
 bool varLesser(Var v1, Var v2) {
   double d1, d2;
+
   if (isNumeric(v1, &d1) && isNumeric(v2, &d2)) {
     return d1 < d2;
   }

--- a/src/pk_core.h
+++ b/src/pk_core.h
@@ -30,14 +30,17 @@ Script* getCoreLib(const PKVM* vm, String* name);
 /* OPERATORS                                                                 */
 /*****************************************************************************/
 
-Var varAdd(PKVM* vm, Var v1, Var v2);      // Returns v1 + v2.
-Var varSubtract(PKVM* vm, Var v1, Var v2); // Returns v1 - v2.
-Var varMultiply(PKVM* vm, Var v1, Var v2); // Returns v1 * v2.
-Var varDivide(PKVM* vm, Var v1, Var v2);   // Returns v1 / v2.
-Var varModulo(PKVM* vm, Var v1, Var v2);   // Returns v1 % v2.
+Var varAdd(PKVM* vm, Var v1, Var v2);         // Returns v1 + v2.
+Var varSubtract(PKVM* vm, Var v1, Var v2);    // Returns v1 - v2.
+Var varMultiply(PKVM* vm, Var v1, Var v2);    // Returns v1 * v2.
+Var varDivide(PKVM* vm, Var v1, Var v2);      // Returns v1 / v2.
+Var varModulo(PKVM* vm, Var v1, Var v2);      // Returns v1 % v2.
 
-Var varBitAnd(PKVM* vm, Var v1, Var v2);   // Returns v1 & v2.
-Var varBitOr(PKVM* vm, Var v1, Var v2);    // Returns v1 | v2.
+Var varBitAnd(PKVM* vm, Var v1, Var v2);      // Returns v1 & v2.
+Var varBitOr(PKVM* vm, Var v1, Var v2);       // Returns v1 | v2.
+Var varBitXor(PKVM* vm, Var v1, Var v2);      // Returns v1 ^ v2.
+Var varBitLshift(PKVM* vm, Var v1, Var v2);   // Returns v1 << v2.
+Var varBitRshift(PKVM* vm, Var v1, Var v2);   // Returns v1 >> v2.
 
 bool varGreater(Var v1, Var v2); // Returns v1 > v2.
 bool varLesser(Var v1, Var v2);  // Returns v1 < v2.

--- a/src/pk_vm.c
+++ b/src/pk_vm.c
@@ -1256,9 +1256,43 @@ static PkResult runFiber(PKVM* vm, Fiber* fiber) {
     }
 
     OPCODE(BIT_XOR):
+    {
+      // Don't pop yet, we need the reference for gc.
+      Var r = PEEK(-1), l = PEEK(-2);
+
+      Var result = varBitXor(vm, l, r);
+      DROP(); DROP(); // r, l
+      PUSH(result);
+
+      CHECK_ERROR();
+      DISPATCH();
+    }
+
     OPCODE(BIT_LSHIFT):
+    {
+      // Don't pop yet, we need the reference for gc.
+      Var r = PEEK(-1), l = PEEK(-2);
+
+      Var result = varBitLshift(vm, l, r);
+      DROP(); DROP(); // r, l
+      PUSH(result);
+
+      CHECK_ERROR();
+      DISPATCH();
+    }
+
     OPCODE(BIT_RSHIFT):
-      TODO;
+    {
+      // Don't pop yet, we need the reference for gc.
+      Var r = PEEK(-1), l = PEEK(-2);
+
+      Var result = varBitRshift(vm, l, r);
+      DROP(); DROP(); // r, l
+      PUSH(result);
+
+      CHECK_ERROR();
+      DISPATCH();
+    }
 
     OPCODE(EQEQ):
     {

--- a/tests/lang/basics.pk
+++ b/tests/lang/basics.pk
@@ -45,6 +45,19 @@ assert((1 & 1) == 1)
 assert((1 & 2) == 0)
 assert((4 & 7) == 4)
 
+assert((1 ^ 1) == 0)
+assert((1 ^ 3) == 2)
+assert((2 ^ 9) == 11)
+assert((0 ^ 0) == 0)
+
+assert((1 << 0) == 1)
+assert((1 << 2) == 4)
+assert((3 << 2) == 12)
+
+assert((8 >> 1) == 4)
+assert((8 >> 2) == 2)
+assert((4 >> 2) == 1)
+
 # If we got here with no errors, then all test passed
 print('All tests PASSED (100%)')
 


### PR DESCRIPTION
This commit addresses issue #54 in an attempt to add more bitwise operators to pocketlang. Tests have also been written to verify that the operators indeed works as expected.

To add, I also introduced a macro PK_RIGHT_OP that just aliases the string "Right operand" which was already getting too hardcoded and appearing too much in the `pk_core.c` file.

*Edit Fix: #54*