### PR TITLE
import name bind bug fix

### DIFF
--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -1321,9 +1321,9 @@ Var varGetAttrib(PKVM* vm, Var on, String* attrib) {
         CASE_ATTRIB("as_list", 0x1562c22):
           return VAR_OBJ(rangeAsList(vm, range));
 
-        // We can't use '.start', '.end' since 'end' in pocketlang is a
-        // keyword. Also we can't use '.from', '.to' since 'from' is a keyword
-        // too. So, we're using '.first' and '.last' to access the range limits.
+        // We can't use 'start', 'end' since 'end' in pocketlang is a
+        // keyword. Also we can't use 'from', 'to' since 'from' is a keyword
+        // too. So, we're using 'first' and 'last' to access the range limits.
 
         CASE_ATTRIB("first", 0x4881d841):
           return VAR_NUM(range->from);

--- a/src/pk_opcodes.h
+++ b/src/pk_opcodes.h
@@ -99,7 +99,8 @@ OPCODE(POP, 0, -1)
 // Pop the path from the stack, import the module at the path and push the
 // script in the script. If the script is imported for the first time (not
 // cached) the script's body will be executed.
-OPCODE(IMPORT, 0, 0)
+// params: 2 byte name index.
+OPCODE(IMPORT, 2, 1)
 
 // Calls a function using stack's top N values as the arguments and once it
 // done the stack top should be stored otherwise it'll be disregarded. The

--- a/src/pk_vm.c
+++ b/src/pk_vm.c
@@ -611,7 +611,17 @@ static PkResult runFiber(PKVM* vm, Fiber* fiber) {
   register CallFrame* frame; //< Current call frame.
   register Script* script;   //< Currently executing script.
 
-#define PUSH(value)  (*vm->fiber->sp++ = (value))
+#if DEBUG
+  #define PUSH(value)                                                        \
+  do {                                                                       \
+    ASSERT(vm->fiber->sp < (vm->fiber->stack + (vm->fiber->stack_size - 1)), \
+           OOPS);                                                            \
+    (*vm->fiber->sp++ = (value));                                            \
+  } while (false)
+#else
+  #define PUSH(value)  (*vm->fiber->sp++ = (value))
+#endif
+
 #define POP()        (*(--vm->fiber->sp))
 #define DROP()       (--vm->fiber->sp)
 #define PEEK(off)    (*(vm->fiber->sp + (off)))

--- a/tests/benchmark/toc/toc.pk
+++ b/tests/benchmark/toc/toc.pk
@@ -1,0 +1,16 @@
+
+## Run the script in pocketlang with
+## toc enabled VS toc disabled
+
+from lang import clock
+
+N = 50000
+
+def woo(n, acc)
+	if n == 0 then return acc end
+	return woo(n-1, acc + '!')
+end
+
+s = clock()
+print(woo(N, ''))
+print('elapsed:', clock() - s)

--- a/tests/lang/toc.pk
+++ b/tests/lang/toc.pk
@@ -7,7 +7,6 @@ from lang import clock
 ## !!CON2019. TAIL CALL OPTIMIZATION (The musical)
 ## https://www.youtube.com/watch?v=-PX0BV9hGZY
 
-## This will cause stack overflow without toc at N = 350
 N = 10000
 
 def woo(n)


### PR DESCRIPTION
Fixed: imported names, override builtin functions (if alias with the same name).
stack corruption (due to missing parameters at compile time) fixed, and some assertion macros added.
