### PR TITLE
bin hex literals implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cl /Fepocket cli/*.c src/*.c /Isrc/include && rm *.obj
 
 1. Create an empty project file / makefile.
 2. Add all C files in the src directory.
-3. Add all C files in the cli directory (**not** recursively).
+3. Add all C files in the cli directory (**NOT** recursively).
 4. Add `src/include` to include path.
 5. Compile.
 

--- a/src/pk_vm.h
+++ b/src/pk_vm.h
@@ -39,7 +39,11 @@
 #define VM_HAS_ERROR(vm) (vm->fiber->error != NULL)
 
 // Set the error message [err] to the [vm]'s current fiber.
-#define VM_SET_ERROR(vm, err) (vm->fiber->error = err)
+#define VM_SET_ERROR(vm, err)        \
+  do {                               \
+    ASSERT(!VM_HAS_ERROR(vm), OOPS); \
+    (vm->fiber->error = err);        \
+  } while (false)
 
 // Builtin functions are stored in an array in the VM (unlike script functions
 // they're member of function buffer of the script) and this struct is a single

--- a/tests/lang/basics.pk
+++ b/tests/lang/basics.pk
@@ -7,6 +7,16 @@ assert(42 % 40.0 == 2)
 assert("'\"'" == '\'"\'')
 assert("testing" == "test" + "ing")
 
+assert(-0b10110010 == -178 and 0b11001010 == 202)
+assert(0b1111111111111111 == 65535)
+assert(
+  0b1111111111111111111111111111111111111111111111111111111111111111 ==
+  18446744073709551615)
+
+assert(0xc0ffee == 12648430)
+assert(0xa1b2c3 == 10597059 and 0xff == 255)
+assert(0xffffffffffffffff == 18446744073709551615)
+
 ## Lists test.
 l1 = [1, false, null, func print('hello') end]
 assert(is_null(l1[2]))
@@ -37,27 +47,26 @@ m['m'] = m
 assert(to_string(m) == '{"m":{...}}')
 
 # Bitwise operation tests
-assert((1 | 1) == 1)
-assert((1 | 4) == 5)
-assert((3 | 5) == 7)
+assert(0b1010 | 0b0101 == 0b1111)
+assert(0b1000 | 0b0001 == 0b1001)
+assert(0b0011 | 0b1001 == 0b1011)
 
-assert((1 & 1) == 1)
-assert((1 & 2) == 0)
-assert((4 & 7) == 4)
+assert(0b1010 & 0b0101 == 0b0000)
+assert(0b1100 & 0b1010 == 0b1000)
+assert(0xabcd & 0xffff == 0xabcd)
 
-assert((1 ^ 1) == 0)
-assert((1 ^ 3) == 2)
-assert((2 ^ 9) == 11)
-assert((0 ^ 0) == 0)
+for i in 0..100 do assert(i^i == 0) end
+assert(0b0001 ^ 0b0011 == 0b0010)
+assert(0b0010 ^ 0b1001 == 0b1011)
 
-assert((1 << 0) == 1)
-assert((1 << 2) == 4)
-assert((3 << 2) == 12)
+assert(0x1 << 0 == 0b1)
+assert(0b1 << 2 == 0b100)
+assert(0b1010 << 2 == 0b101000)
 
-assert((1 >> 1) == 0)
-assert((8 >> 1) == 4)
-assert((8 >> 2) == 2)
-assert((4 >> 2) == 1)
+assert(0b1 >> 1 == 0)
+assert(8 >> 1 == 0x4)
+assert(8 >> 2 == 0b10)
+assert(0xa >> 1 == 5)
 
 x = 42  ; assert((x&=51) == 34)
 x = 123 ; assert((x&=324) == 64)
@@ -81,6 +90,6 @@ for i in 0..1000
   x = i; assert((x^=-1) == -i-1)
 end
 
-# If we got here with no errors, then all test passed
-print('All tests PASSED (100%)')
 
+# If we got here, that means all test were passed.
+print('All TESTS PASSED')

--- a/tests/lang/controlflow.pk
+++ b/tests/lang/controlflow.pk
@@ -56,3 +56,5 @@ end
 assert(sum == 54)
 
 
+# If we got here, that means all test were passed.
+print('All TESTS PASSED')

--- a/tests/lang/core.pk
+++ b/tests/lang/core.pk
@@ -4,6 +4,8 @@ assert(hex(12648430) == '0xc0ffee')
 assert(hex(255) == '0xff' and hex(10597059) == '0xa1b2c3')
 assert(hex(-4294967295) == '-0xffffffff') ## the largest.
 
+
+
 ## string attributes.
 assert(''.length == 0)
 assert('test'.length == 4)
@@ -49,6 +51,6 @@ for i in 0..1000
   assert(abs(sin(i) / cos(i) - tan(i)) < threshold)
 end
 
-# If we got here with no errors, then all test passed
-print('All tests PASSED (100%)')
 
+# If we got here, that means all test were passed.
+print('All TESTS PASSED')

--- a/tests/lang/fibers.pk
+++ b/tests/lang/fibers.pk
@@ -31,3 +31,6 @@ p2 = fiber_resume(fiber, 'r1'); assert(p2 == 2)
 p1 = fiber_resume(fiber, 'r2'); assert(p1 == 1)
 pa = fiber_resume(fiber, 'r3'); assert(pa == 7)
 assert(fiber_is_done(fiber))
+
+# If we got here, that means all test were passed.
+print('All TESTS PASSED')

--- a/tests/lang/functions.pk
+++ b/tests/lang/functions.pk
@@ -25,3 +25,6 @@ assert(result == '[fn3:[fn2:[fn1:data]|suff]]')
 # str_lower(s) function refactored to s.lower attribute.
 #result = ' tEST+InG ' -> str_strip -> str_lower
 #assert(result == 'test+ing')
+
+# If we got here, that means all test were passed.
+print('All TESTS PASSED')

--- a/tests/lang/import.pk
+++ b/tests/lang/import.pk
@@ -32,3 +32,5 @@ import 'import/all_import.pk' as all_import
 assert(all_import.all_f1 == all_f1)
 
 
+# If we got here, that means all test were passed.
+print('All TESTS PASSED')

--- a/tests/lang/toc.pk
+++ b/tests/lang/toc.pk
@@ -72,3 +72,5 @@ for i in 0..100
 end
 
 
+# If we got here, that means all test were passed.
+print('All TESTS PASSED')


### PR DESCRIPTION
binary literals `0b100110101` and hex literals `0xa1b2c2ffe` added to the parser.
and `bin()` function implemented.

yet the `hex()` function should be refactor from `sprintf("%x")` to our own version (like bin()).
