### PR TITLE
tests: allow tests to be called from anywhere

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run check.py script.
         run: |
-          cd tests
-          python3 check.py
+          python3 tests/check.py
   
   ## Compile and run test on linux system.
   linux-build:
@@ -24,8 +23,7 @@ jobs:
           make
       - name: Run tests.
         run: |
-          cd tests
-          python3 tests.py
+          python3 tests/tests.py
 
   ## Compile and run tests on windows system.
   windows-build:
@@ -38,8 +36,7 @@ jobs:
           cmd /c build.bat
       - name: Run tests.
         run: |
-          cd tests
-          python tests.py
+          python3 tests/tests.py
 
   ## Compile and run tests on macos system.
   macos-build:
@@ -52,7 +49,6 @@ jobs:
           make
       - name: Run tests.
         run: |
-          cd tests
-          python3 tests.py
+          python3 tests/tests.py
 
 

--- a/tests/check.py
+++ b/tests/check.py
@@ -9,6 +9,15 @@ import os, sys, re
 from os.path import join
 from os import listdir
 
+## The absolute path of this file, when run as a script.
+## This file is not intended to be included in other files at the moment.
+THIS_PATH = os.path.abspath(os.path.dirname(__file__))
+
+## Converts a list of relative paths from the working directory
+## to a list of relative paths from this file's absolute directory.
+def to_abs_paths(sources):
+  return map(lambda s: os.path.join(THIS_PATH, s), sources)
+
 ## A list of source files, to check if the fnv1a hash values match it's
 ## corresponding cstring in the CASE_ATTRIB(name, hash) macro calls.
 HASH_CHECK_LIST = [
@@ -26,9 +35,9 @@ C_SOURCE_DIRS = [
 ## This global variable will be set to true if any check failed.
 checks_failed = False
 
-def main():    
-  check_fnv1_hash(HASH_CHECK_LIST)
-  check_static(C_SOURCE_DIRS)
+def main():
+  check_fnv1_hash(to_abs_paths(HASH_CHECK_LIST))
+  check_static(to_abs_paths(C_SOURCE_DIRS))
   if checks_failed:
     sys.exit(1)
   print("Static checks were passed.")
@@ -117,4 +126,3 @@ def report_error(msg):
 
 if __name__ == '__main__':
   main()
-  

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,6 +8,10 @@ from os.path import join
 
 ## TODO: Re write this in doctest (https://github.com/onqtam/doctest)
 
+## The absolute path of this file, when run as a script.
+## This file is not intended to be included in other files at the moment.
+THIS_PATH = os.path.abspath(os.path.dirname(__file__))
+
 ## All the test files.
 TEST_SUITE = {
   "Unit Tests": (
@@ -29,6 +33,13 @@ TEST_SUITE = {
   ),
 }
 
+## Map from systems to the relative binary path
+SYSTEM_TO_BINARY_PATH = {
+  "Windows": "..\\build\\debug\\bin\\pocket.exe",
+  "Linux": "../build/debug/pocket",
+  "Darwin": "../build/debug/pocket",
+}
+
 ## This global variable will be set to true if any test failed.
 tests_failed = False
 def main():
@@ -46,13 +57,14 @@ def run_all_tests():
   
   for suite in TEST_SUITE:
     print_title(suite)
-    for path in TEST_SUITE[suite]:
-      run_test_file(pocket, path)
+    for test in TEST_SUITE[suite]:
+      path = os.path.join(THIS_PATH, test)
+      run_test_file(pocket, test, path)
 
-def run_test_file(pocket, path):
+def run_test_file(pocket, test, path):
   FMT_PATH = "%-25s"
   INDENTATION = '  | '
-  print(FMT_PATH % path, end='')
+  print(FMT_PATH % test, end='')
 
   sys.stdout.flush()
   result = run_command([pocket, path])
@@ -69,22 +81,13 @@ def run_test_file(pocket, path):
 ## The debug version of it for enabling the assertions.
 def get_pocket_binary():
   system = platform.system()
-  pocket = ''
-  if system == 'Windows':
-    pocket = "..\\build\\debug\\bin\\pocket.exe"
-    
-  elif system == 'Linux':
-    pocket = "../build/debug/pocket"
-    
-  elif system == 'Darwin':
-    pocket = "../build/debug/pocket"
-  
-  else:
+  if system not in SYSTEM_TO_BINARY_PATH:
     error_exit("Unsupported platform %s" % system)
-    
+
+  pocket = os.path.join(THIS_PATH, SYSTEM_TO_BINARY_PATH[system])
   if not os.path.exists(pocket):
     error_exit("Pocket interpreter not found at: '%s'" % pocket)
-  
+
   return pocket
 
 def run_command(command):


### PR DESCRIPTION
Currently, it is required for the shell's working directory to be in
the repo's test/ directory in order for the tests to run correctly.
This also applies for the static analysis checker.

The reason for this is that paths in the test orchestration code are
defined relative to the test directory. Instead, and since none of
these scripts are modules that will in the forseeable future be
imported into other files, we update all paths to be relative
to the absolute path of the script's file itself.

┏( ͡❛ ͜ʖ ͡❛)┛