### PR TITLE
Introduce the use of function attribute (__attribute__)

### DIFF
--- a/cli/common.h
+++ b/cli/common.h
@@ -98,6 +98,12 @@
 #define TOSTRING(x) #x
 #define STRINGIFY(x) TOSTRING(x)
 
+// Function attribute: this macro is used to bypass Windows build
+// failing since it doesn't recognize the attribute.
+#if defined( WIN32 ) || defined( _WIN32 ) || defined( __WIN32__ )
+  #define __attribute__(X)
+#endif
+
 /*****************************************************************************/
 /* CLI DEFINES                                                               */
 /*****************************************************************************/

--- a/cli/main.c
+++ b/cli/main.c
@@ -8,6 +8,9 @@
 // FIXME: Everything below here is temporary and for testing.
 
 void repl(PKVM* vm, const PkCompileOptions* options);
+
+const char* read_line(uint32_t* length)
+  __attribute__ ((deprecated("Use readLine() instead")));
 const char* read_line(uint32_t* length);
 
 void registerModules(PKVM* vm);


### PR DESCRIPTION
Begin using it to mark functions that have a better version such as `read_line()` which has a better version: `readLine()` that uses a byte buffer.

Through out the code base, if we see functions that have a better version of itself, we should definitely mark it as deprecated with a meaningful deprecation message.

In effect, the GCC compiler will through a warning level message on the console at compile time reporting these deprecated functions.