### PR TITLE
chore: include nodejs benchmarks

### DIFF
--- a/tests/benchmark/benchmarks.py
+++ b/tests/benchmark/benchmarks.py
@@ -6,11 +6,11 @@ from os.path import join
 
 ## All benchmark files. ## TODO: pass args for iterations.
 benchmarks = {
-  "factors"      : ['.pk', '.py', '.rb', '.wren'],
-  "fib"          : ['.pk', '.py', '.rb', '.wren'],
-  "list"         : ['.pk', '.py', '.rb'],
-  "loop"         : ['.pk', '.py', '.rb', ".wren"],
-  "primes"       : ['.pk', '.py', '.rb', ".wren"],
+  "factors"      : ['.pk', '.py', '.rb', '.js', '.wren'],
+  "fib"          : ['.pk', '.py', '.rb', '.js', '.wren'],
+  "list"         : ['.pk', '.py', '.rb', '.js'],
+  "loop"         : ['.pk', '.py', '.rb', '.js', '.wren'],
+  "primes"       : ['.pk', '.py', '.rb', '.js', '.wren'],
 }
 
 def main():
@@ -24,6 +24,7 @@ def run_all_benchmarks():
     if file.endswith('.py'  ) : return 'python'
     if file.endswith('.rb'  ) : return 'ruby'
     if file.endswith('.wren') : return 'wren'
+    if file.endswith('.js'  ) : return 'node'
     assert False
 
   for bm_name in benchmarks:

--- a/tests/benchmark/factors/factors.js
+++ b/tests/benchmark/factors/factors.js
@@ -3,7 +3,7 @@
 // which makes more faster than other bytecode interpreted
 // VM language listed here.
 
-var start = process.hrtime()
+var start = process.hrtime();
 
 var N = 50000000;
 var i=0, factors = []
@@ -11,6 +11,6 @@ for (; i <= N; i++) {
 	if (N % i === 0) factors.push(i);
 }
 
-var end = process.hrtime(end);
+var end = process.hrtime(start);
 var secs = (end[0] + end[1] / 1e9).toFixed(6) + 's';
 console.log('elapsed:', secs);

--- a/tests/benchmark/factors/factors.js
+++ b/tests/benchmark/factors/factors.js
@@ -3,13 +3,14 @@
 // which makes more faster than other bytecode interpreted
 // VM language listed here.
 
-var start = +new Date();
+var start = process.hrtime()
 
 var N = 50000000;
-var factors = []
-for (var i = 0; i <= N; i++) {
-	if (N % i == 0) factors.push(i);
+var i=0, factors = []
+for (; i <= N; i++) {
+	if (N % i === 0) factors.push(i);
 }
 
-var end = +new Date();
-console.log('elapsed: ' + (end - start)/1000 + 's');
+var end = process.hrtime(end);
+var secs = (end[0] + end[1] / 1e9).toFixed(6) + 's';
+console.log('elapsed:', secs);

--- a/tests/benchmark/fib/fib.js
+++ b/tests/benchmark/fib/fib.js
@@ -1,0 +1,13 @@
+function fib(n) {
+	if (n < 2) return n;
+	return fib(n - 1) + fib(n - 2);
+}
+
+var start = process.hrtime();
+for (var i=0; i < 10; i++) {
+	process.stdout.write(fib(30) + '\n');
+}
+
+var end = process.hrtime(start);
+var secs = (end[0] + end[1] / 1e9).toFixed(6) + 's';
+console.log('elapsed:', secs);

--- a/tests/benchmark/list/list.js
+++ b/tests/benchmark/list/list.js
@@ -1,0 +1,19 @@
+function reverse(list) {
+	var i=0, tmp, idx, count=list.length;
+	for (; i < count; i++) {
+		idx = count - i - 1;
+		tmp = list[idx];
+		list[idx] = list[i];
+		list[i] = tmp;
+	}
+}
+
+var start = process.hrtime();
+
+var i=0, N=20000000, list=Array(N);
+for (; i < N; i++) list[i] = i;
+reverse(list);
+
+var end = process.hrtime(start);
+var secs = (end[0] + end[1] / 1e9).toFixed(6) + 's';
+console.log('elapsed:', secs);

--- a/tests/benchmark/loop/loop.js
+++ b/tests/benchmark/loop/loop.js
@@ -3,13 +3,15 @@
 // which makes more faster than other bytecode interpreted
 // VM language listed here.
 
-var start = +new Date();
+var start = process.hrtime();
 
-list = []
-for (var i = 0; i < 10000000; i++) { list.push(i) }
-sum = 0
-for (var i = 0; i < list.length; i++) { sum += list[i]; }
-console.log(sum)
+var i=0, list=[];
+for (; i < 10000000; i++) list.push(i);
 
-var end = +new Date();
-console.log('elapsed: ' + (end - start)/1000 + 's');
+var sum = 0;
+for (i=0; i < list.length; i++) sum += list[i];
+console.log(sum);
+
+var end = process.hrtime(start);
+var secs = (end[0] + end[1] / 1e9).toFixed(6) + 's';
+console.log('elapsed:', secs);

--- a/tests/benchmark/primes/primes.js
+++ b/tests/benchmark/primes/primes.js
@@ -1,0 +1,20 @@
+function isPrime(n) {
+	if (n < 2) return false;
+	for (var i=2; i < n; i++) {
+		if (n % i === 0) return false;
+	}
+	return true;
+}
+
+var start = process.hrtime();
+
+var i=0, N=30000, primes=[];
+for (; i < N; i++) {
+	if (isPrime(i)) {
+		primes.push(i);
+	}
+}
+
+var end = process.hrtime(start);
+var secs = (end[0] + end[1] / 1e9).toFixed(6) + 's';
+console.log('elapsed:', secs);


### PR DESCRIPTION
Moved the existing `factors.js` and `loop.js` to use [`process.hrtime`](https://nodejs.org/api/process.html#process_process_hrtime_time) for high-resolution time measurements. It's been in Node since 0.x so is safe to assume all `node` users have it in their current Node version(s).

Also fixed `loop.js`, which had `sum` and `list` variable references that were not declared. This negatively impacts performance & is very heavily discouraged across the language.

> Related #124