### PR TITLE
add exit() function

### DIFF
--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -631,7 +631,7 @@ DEF(coreExit,
   "Sets the VM's fiber to NULL, causing the VM to return from execution "
   "and thereby terminating the process entirely. The exit code of the "
   "process is the optional argument [value] given to exit() which must be "
-  "between 0 and 255 inclusive. If no argument is given, the exit code is 1 "
+  "between 0 and 255 inclusive. If no argument is given, the exit code is 0 "
   "by default.") {
 
   int argc = ARGC;
@@ -639,12 +639,14 @@ DEF(coreExit,
     RET_ERR(newString(vm, "Invalid argument count."));
   }
 
-  int64_t value;
-  // if (!validateInteger(vm, ARG(1), &value, "Argument 1")) return;
-  if (!validateIntegerRange(vm, ARG(1), &value, 0, 255, "Argument 1")) return;
+  int64_t value = 0;
+  if (argc == 1) {
+    if (!validateIntegerRange(vm, ARG(1), &value, 0, 255, "Argument 1"))
+      return;
+  }
 
   // TODO: this actually needs to be the VM fiber being set to null though.
-  exit((argc == 1) ? value : EXIT_FAILURE);
+  exit(value);
 }
 
 // String functions.

--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -606,13 +606,32 @@ DEF(coreInput,
   RET(VAR_OBJ(line));
 }
 
+DEF(coreExit,
+  "exit([value:int]) -> null\n"
+  "Sets the VM's fiber to NULL, causing the VM to return from execution "
+  "and thereby terminating the process entirely. The exit code of the "
+  "process is the optional argument [value] given to exit(). If no argument "
+  "is given, the exit code is 1 by default.") {
+
+  int argc = ARGC;
+  if (argc > 1) { // exit() or exit(val).
+    RET_ERR(newString(vm, "Invalid argument count."));
+  }
+
+  int64_t value;
+  if (!validateInteger(vm, ARG(1), &value, "Argument 1")) return;
+
+  // TODO: this actually needs to be the VM fiber being set to null though.
+  exit((argc == 1) ? value : EXIT_FAILURE);
+}
+
 // String functions.
 // -----------------
 
 // TODO: substring.
 
 DEF(coreStrChr,
-  "str_chr(value:number) -> string\n"
+  "str_chr(value:num) -> string\n"
   "Returns the ASCII string value of the integer argument.") {
   int64_t num;
   if (!validateInteger(vm, ARG(1), &num, "Argument 1")) return;
@@ -626,7 +645,7 @@ DEF(coreStrChr,
 }
 
 DEF(coreStrOrd,
-  "str_ord(value:string) -> number\n"
+  "str_ord(value:string) -> num\n"
   "Returns integer value of the given ASCII character.") {
 
   String* c;
@@ -1014,6 +1033,7 @@ void initializeCore(PKVM* vm) {
   INITIALIZE_BUILTIN_FN("to_string",   coreToString,   1);
   INITIALIZE_BUILTIN_FN("print",       corePrint,     -1);
   INITIALIZE_BUILTIN_FN("input",       coreInput,     -1);
+  INITIALIZE_BUILTIN_FN("exit",        coreExit,      -1);
 
   // String functions.
   INITIALIZE_BUILTIN_FN("str_chr",     coreStrChr,     1);

--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -9,7 +9,6 @@
 #include <limits.h>
 #include <math.h>
 #include <time.h>
-#include <inttypes.h>
 
 #include "pk_debug.h"
 #include "pk_utils.h"
@@ -349,25 +348,6 @@ static inline bool validateInteger(PKVM* vm, Var var, int64_t* value,
   return false;
 }
 
-// Check if [var] is 32bit integer and is within the given range. If not
-// set error and return false.
-static inline bool validateIntegerRange(PKVM* vm, Var var, int64_t* value,
-                                   int64_t lower, int64_t upper,
-                                   const char* name) {
-  if (!validateInteger(vm, var, value, name)) return false;
-  if ((lower <= *value) && (*value <= upper)) return true;
-
-  char lowerChar[sizeof(int64_t)];
-  snprintf(lowerChar, sizeof(lowerChar), "%" PRIi64, lower);
-
-  char upperChar[sizeof(int64_t)];
-  snprintf(upperChar, sizeof(upperChar), "%" PRIi64, upper);
-
-  VM_SET_ERROR(vm, stringFormat(vm, "$ must be between $ and $, inclusive.",
-        name, lowerChar, upperChar));
-  return false;
-}
-
 // Index is could be larger than 32 bit integer, but the size in pocketlang
 // limited to 32 unsigned bit integer
 static inline bool validateIndex(PKVM* vm, int64_t index, uint32_t size,
@@ -641,8 +621,7 @@ DEF(coreExit,
 
   int64_t value = 0;
   if (argc == 1) {
-    if (!validateIntegerRange(vm, ARG(1), &value, 0, 255, "Argument 1"))
-      return;
+    if (!validateInteger(vm, ARG(1), &value, "Argument 1")) return;
   }
 
   // TODO: this actually needs to be the VM fiber being set to null though.


### PR DESCRIPTION
- I couldn't find any tests for existing `core*` functions, and since this exits the entire process how would we test it?
- As per the docstring for the function I set the default exit code to `EXIT_FAILURE` (equivalent to `1`) because it's most likely (I think) that `exit()` would be called like that in situations requiring termination due to some bad world-state, say a bad argument or an error. The requirement to exit successfully, which is still possible, could naturally happen by way of the process ending normally so defaulting `exit()` to `EXIT_SUCCESS` (equivalent to `0`) didn't seem right.
- I also corrected a small typo I found along the way.

Discussed issue: https://github.com/ThakeeNathees/pocketlang/issues/122