### PR TITLE
imported scripts were initialized

### DIFF
--- a/docs/TODO.txt
+++ b/docs/TODO.txt
@@ -4,23 +4,13 @@ Add '.title' attribute to string
 
 // To implement.
 
-- refactor the build.bat script.
-
-- no __file__ for core modules.
-
-- def f(x)
-    f(x) ## not tco, unless return f(x)
-  end
-  if a function's last statement is a call, we can perform tco.
+- make assert as a keyword (like python) and disable it on release build.
 
 - implement 'lang.getMaxCallDepth()' (default=1000 like python) and
   setMaxCallDepth(val) to change stack size at runtime.
 
 - change or add => to_string() to value.as_string
   and add as_repr, as_bool.
-
-- Make bool and num are incompatible (also it increase performance a bit).
-  1 + true - make it not allowed.
   
 - literal function recursive call.
   fn = func(a, b)
@@ -30,7 +20,6 @@ Add '.title' attribute to string
 
 - Implement utf8 support.
 - Implement gdb like debugger (add color print for readability).
-- Initialize imported scripts (require fiber based vm).
 - Complete all the TODO; macros.
 - implement MAX_ARGC checks (would cause a buffer overflow if not)
   when compiling and calling a function (also in fibers).

--- a/src/include/pocketlang.h
+++ b/src/include/pocketlang.h
@@ -77,7 +77,7 @@ typedef struct PkHandle PkHandle;
 typedef void* PkVar;
 
 // Type enum of the pocketlang variables, this can be used to get the type
-// from a Var* in the method pkGetVarType().
+// from a PkVar in the method pkGetVarType().
 typedef enum {
   PK_NULL,
   PK_BOOL,
@@ -109,9 +109,6 @@ typedef enum {
 // or a function or evaluating an expression.
 typedef enum {
   PK_RESULT_SUCCESS = 0,    // Successfully finished the execution.
-
-  // This will be set to `true` if we're running REPL mode and reached an EOF
-  // unexpectedly, 
 
   // Unexpected EOF while compiling the source. This is another compile time
   // error that will ONLY be returned if we're compiling with the REPL mode set
@@ -216,7 +213,7 @@ PK_PUBLIC PkConfiguration pkNewConfiguration(void);
 // application.
 PK_PUBLIC PkCompileOptions pkNewCompilerOptions(void);
 
-// Allocate, initialize and returns a new VM
+// Allocate, initialize and returns a new VM.
 PK_PUBLIC PKVM* pkNewVM(PkConfiguration* config);
 
 // Clean the VM and dispose all the resources allocated by the VM.
@@ -332,14 +329,6 @@ struct PkCompileOptions {
   // Compile debug version of the source.
   bool debug;
 
-  // TODO: don't use FILE* pointer or any of <stdio.h> functions here.
-  //       instead add a stream option to vm.config.write_fn callback.
-  // 
-  // Dump the compiled opcodes to the given [dump_stream] FILE* could be stdio,
-  // stderr, or a file pointer.
-  //bool dump_opcodes;
-  //FILE* dump_stream;
-
   // Set to true if compiling in REPL mode, This will print repr version of
   // each evaluated non-null values. Note that if [repl_mode] is true the
   // [expression] should also be true otherwise it's incompatible, (will fail
@@ -443,9 +432,11 @@ PK_PUBLIC PkHandle* pkNewFiber(PKVM* vm, PkHandle* fn);
 // callback.
 PK_PUBLIC PkHandle* pkNewInstNative(PKVM* vm, void* data, uint32_t id);
 
-// TODO: The functions below will push the primitive values on the stack
-// and return it's pointer as a PkVar. It's useful to convert your primitive
-// values as pocketlang variables.
+// TODO: Create a primitive (non garbage collected) variable buffer (or a
+// fixed size array) to store them and make the handle points to the variable
+// in that buffer, this will prevent us from invoking an allocation call for
+// each time we want to pass a primitive type.
+
 //PK_PUBLIC PkVar pkPushNull(PKVM* vm);
 //PK_PUBLIC PkVar pkPushBool(PKVM* vm, bool value);
 //PK_PUBLIC PkVar pkPushNumber(PKVM* vm, double value);

--- a/src/pk_compiler.c
+++ b/src/pk_compiler.c
@@ -2215,7 +2215,7 @@ static Script* importFile(Compiler* compiler, const char* path) {
   }
 
   // Make a new script and to compile it.
-  Script* scr = newScript(vm, path_name);
+  Script* scr = newScript(vm, path_name, false);
   vmPushTempRef(vm, &scr->_super); // scr.
   mapSet(vm, vm->scripts, VAR_OBJ(path_name), VAR_OBJ(scr));
   vmPopTempRef(vm); // scr.

--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -757,8 +757,7 @@ static Script* newModuleInternal(PKVM* vm, const char* name) {
              "A module named '$' already exists", name)->data);
   }
 
-  Script* scr = newScript(vm, _name);
-  scr->module = _name;
+  Script* scr = newScript(vm, _name, true);
   vmPopTempRef(vm); // _name
 
   // Add the script to core_libs.

--- a/src/pk_opcodes.h
+++ b/src/pk_opcodes.h
@@ -108,9 +108,9 @@ OPCODE(PUSH_BUILTIN_FN, 1, 1)
 // Pop the stack top.
 OPCODE(POP, 0, -1)
 
-// Pop the path from the stack, import the module at the path and push the
-// script in the script. If the script is imported for the first time (not
-// cached) the script's body will be executed.
+// Push the pre-compiled module at the index (from opcode) on the stack, and
+// initialize the module (ie. run the main function) if it's not initialized
+// already.
 // params: 2 byte name index.
 OPCODE(IMPORT, 2, 1)
 

--- a/src/pk_var.h
+++ b/src/pk_var.h
@@ -437,8 +437,12 @@ Map* newMap(PKVM* vm);
 // Allocate new Range object and return Range*.
 Range* newRange(PKVM* vm, double from, double to);
 
-// Allocate new Script object and return Script*.
-Script* newScript(PKVM* vm, String* path);
+// Allocate new Script object and return Script*, if the argument [is_core] is
+// true the script will be used as a core module and the body of the script
+// would be NULL and the [name] will be used as the module name. Otherwise the
+// [name] will be used as the path of the module and a main function will be
+// allocated for the module.
+Script* newScript(PKVM* vm, String* name, bool is_core);
 
 // Allocate new Function object and return Function*. Parameter [name] should
 // be the name in the Script's nametable. If the [owner] is NULL the function

--- a/tests/lang/import.pk
+++ b/tests/lang/import.pk
@@ -35,6 +35,15 @@ assert(all_f3() == 'f3')
 import 'import/all_import.pk' as all_import
 assert(all_import.all_f1 == all_f1)
 
+## Test if the imported globals were initialized
+import 'import/globals.pk'
+assert(g_import != null)
+assert(g_import.g_var_1 == 3)
+assert(g_import.g_var_2 == g_import.get_a_value())
+
+import 'import/globals2.pk'
+assert(g_val_1 == 100)
+assert(g_val_2 == get_a_value())
 
 # If we got here, that means all test were passed.
 print('All TESTS PASSED')

--- a/tests/lang/import/globals.pk
+++ b/tests/lang/import/globals.pk
@@ -1,0 +1,9 @@
+
+module g_import
+
+g_var_1 = 1 + 2
+g_var_2 = get_a_value()
+
+def get_a_value()
+  return "foobar"
+end

--- a/tests/lang/import/globals2.pk
+++ b/tests/lang/import/globals2.pk
@@ -1,0 +1,11 @@
+
+g_val_1 = 0
+for i in 0..100
+  g_val_1 += 1
+end
+
+g_val_2 = get_a_value()
+
+def get_a_value()
+  return "baz"
+end


### PR DESCRIPTION
The implicit main function will be executed when a module is imported to initialize the module. Once a module is initialized the main won't be executed anymore in order to prevent cyclic import crashes.