### PR TITLE
Fix various warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 ##  Distributed Under The MIT License
 
 CC             = gcc
-CFLAGS         = -fPIC
+CFLAGS         = -fPIC -std=c99
 DEBUG_CFLAGS   = -D DEBUG -g3 -Og -Wall -Wextra 
 RELEASE_CFLAGS = -g -O3
 LDFLAGS        = -lm

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 CC             = gcc
 CFLAGS         = -fPIC
-DEBUG_CFLAGS   = -D DEBUG -g3 -Og
+DEBUG_CFLAGS   = -D DEBUG -g3 -Og -Wall -Wextra 
 RELEASE_CFLAGS = -g -O3
 LDFLAGS        = -lm
 

--- a/cli/common.h
+++ b/cli/common.h
@@ -17,9 +17,11 @@
 #if defined(__GNUC__)
   #pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
   #pragma GCC diagnostic ignored "-Wunused-parameter"
+  #pragma GCC diagnostic ignored "-Wtype-limits"
 #elif defined(__clang__)
   #pragma clang diagnostic ignored "-Wint-to-pointer-cast"
   #pragma clang diagnostic ignored "-Wunused-parameter"
+  #pragma clang diagnostic ignored "-Wtype-limits"
 #endif
 
 #include <stdio.h> //< Only needed here for ASSERT() macro and for release mode

--- a/cli/modules.c
+++ b/cli/modules.c
@@ -39,9 +39,9 @@ bool objSetAttrib(PKVM* vm, void* instance, uint32_t id, PkStringPtr attrib) {
   ASSERT(obj->type == (ObjType)id, OOPS);
 
   if (obj->type == OBJ_FILE) {
-    [[maybe_unused]]
     File* file = (File*)obj;
     // Nothing to change.
+    (void)file;
   }
 
   return false;

--- a/cli/modules.c
+++ b/cli/modules.c
@@ -39,6 +39,7 @@ bool objSetAttrib(PKVM* vm, void* instance, uint32_t id, PkStringPtr attrib) {
   ASSERT(obj->type == (ObjType)id, OOPS);
 
   if (obj->type == OBJ_FILE) {
+    [[maybe_unused]]
     File* file = (File*)obj;
     // Nothing to change.
   }

--- a/cli/repl.c
+++ b/cli/repl.c
@@ -104,7 +104,7 @@ int repl(PKVM* vm, const PkCompileOptions* options) {
     byteBufferWrite(&lines, '\0');
 
     // Compile the buffer to the module.
-    PkStringPtr source_ptr = { (const char*)lines.data, NULL, NULL };
+    PkStringPtr source_ptr = { (const char*)lines.data, NULL, NULL, 0, 0 };
     PkResult result = pkCompileModule(vm, module, source_ptr, options);
 
     if (result == PK_RESULT_UNEXPECTED_EOF) {

--- a/src/pk_common.h
+++ b/src/pk_common.h
@@ -17,9 +17,11 @@
 #if defined(__GNUC__)
   #pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
   #pragma GCC diagnostic ignored "-Wunused-parameter"
+  #pragma GCC diagnostic ignored "-Wtype-limits"
 #elif defined(__clang__)
   #pragma clang diagnostic ignored "-Wint-to-pointer-cast"
   #pragma clang diagnostic ignored "-Wunused-parameter"
+  #pragma clang diagnostic ignored "-Wtype-limits"
 #endif
 
 #include <stdio.h> //< Only needed here for ASSERT() macro and for release mode
@@ -64,22 +66,8 @@
 
 #define ASSERT(condition, message) __ASSERT(condition, message)
 
-#if defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wtype-limits"
-#elif defined(__clang__)
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wtype-limits"
-#endif
-
 #define ASSERT_INDEX(index, size) \
   ASSERT(index >= 0 && index < size, "Index out of bounds.")
-
-#if defined(__GNUC__)
-  #pragma GCC diagnostic pop
-#elif defined(__clang__)
-  #pragma clang diagnostic pop
-#endif
 
 #define UNREACHABLE()                                                \
   do {                                                               \

--- a/src/pk_common.h
+++ b/src/pk_common.h
@@ -64,8 +64,22 @@
 
 #define ASSERT(condition, message) __ASSERT(condition, message)
 
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wtype-limits"
+#elif defined(__clang__)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wtype-limits"
+#endif
+
 #define ASSERT_INDEX(index, size) \
   ASSERT(index >= 0 && index < size, "Index out of bounds.")
+
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#elif defined(__clang__)
+  #pragma clang diagnostic pop
+#endif
 
 #define UNREACHABLE()                                                \
   do {                                                               \

--- a/src/pk_compiler.c
+++ b/src/pk_compiler.c
@@ -2172,7 +2172,7 @@ static Script* importFile(Compiler* compiler, const char* path) {
   PKVM* vm = compiler->vm;
 
   // Resolve the path.
-  PkStringPtr resolved = { path, NULL, NULL };
+  PkStringPtr resolved = { path, NULL, NULL, 0, 0 };
   if (vm->config.resolve_path_fn != NULL) {
     resolved = vm->config.resolve_path_fn(vm, compiler->script->path->data,
                                           path);

--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -516,7 +516,7 @@ DEF(coreBin,
   "bin(value:num) -> string\n"
   "Returns as a binary value string with '0x' prefix.") {
 
-  int64_t value;
+  int64_t value = 0;
   if (!validateInteger(vm, ARG(1), &value, "Argument 1")) return;
 
   char buff[STR_BIN_BUFF_SIZE];
@@ -547,7 +547,7 @@ DEF(coreHex,
   "hex(value:num) -> string\n"
   "Returns as a hexadecimal value string with '0x' prefix.") {
 
-  int64_t value;
+  int64_t value = 0;
   if (!validateInteger(vm, ARG(1), &value, "Argument 1")) return;
 
   char buff[STR_HEX_BUFF_SIZE];
@@ -660,8 +660,8 @@ DEF(coreStrSub,
   "the position and length of the substring are provided when this "
   "function is called. For example: `str_sub(str, pos, len)`.") {
 
-  String* str;
-  int64_t pos, len;
+  String* str = NULL;
+  int64_t pos = 0, len = 0;
 
   if (!validateArgString(vm, 1, &str)) return;
   if (!validateInteger(vm, ARG(2), &pos, "Argument 2")) return;
@@ -683,7 +683,7 @@ DEF(coreStrChr,
   "str_chr(value:num) -> string\n"
   "Returns the ASCII string value of the integer argument.") {
 
-  int64_t num;
+  int64_t num = 0;
   if (!validateInteger(vm, ARG(1), &num, "Argument 1")) return;
 
   if (!IS_NUM_BYTE(num)) {
@@ -888,7 +888,7 @@ DEF(stdLangWrite,
 DEF(stdMathFloor,
   "floor(value:num) -> num\n") {
 
-  double num;
+  double num = 0;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   RET(VAR_NUM(floor(num)));
 }
@@ -896,7 +896,7 @@ DEF(stdMathFloor,
 DEF(stdMathCeil,
   "ceil(value:num) -> num\n") {
 
-  double num;
+  double num = 0;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   RET(VAR_NUM(ceil(num)));
 }
@@ -904,7 +904,7 @@ DEF(stdMathCeil,
 DEF(stdMathPow,
   "pow(value:num) -> num\n") {
 
-  double num, ex;
+  double num = 0, ex = 0;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   if (!validateNumeric(vm, ARG(2), &ex, "Argument 2")) return;
   RET(VAR_NUM(pow(num, ex)));
@@ -913,7 +913,7 @@ DEF(stdMathPow,
 DEF(stdMathSqrt,
   "sqrt(value:num) -> num\n") {
 
-  double num;
+  double num = 0;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   RET(VAR_NUM(sqrt(num)));
 }
@@ -921,7 +921,7 @@ DEF(stdMathSqrt,
 DEF(stdMathAbs,
   "abs(value:num) -> num\n") {
 
-  double num;
+  double num = 0;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   if (num < 0) num = -num;
   RET(VAR_NUM(num));
@@ -930,7 +930,7 @@ DEF(stdMathAbs,
 DEF(stdMathSign,
   "sign(value:num) -> num\n") {
 
-  double num;
+  double num = 0;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   if (num < 0) num = -1;
   else if (num > 0) num = +1;
@@ -956,7 +956,7 @@ DEF(stdMathSine,
   "Return the sine value of the argument [rad] which is an angle expressed "
   "in radians.") {
 
-  double rad;
+  double rad = 0;
   if (!validateNumeric(vm, ARG(1), &rad, "Argument 1")) return;
   RET(VAR_NUM(sin(rad)));
 }
@@ -966,7 +966,7 @@ DEF(stdMathCosine,
   "Return the cosine value of the argument [rad] which is an angle expressed "
   "in radians.") {
 
-  double rad;
+  double rad = 0;
   if (!validateNumeric(vm, ARG(1), &rad, "Argument 1")) return;
   RET(VAR_NUM(cos(rad)));
 }
@@ -976,7 +976,7 @@ DEF(stdMathTangent,
   "Return the tangent value of the argument [rad] which is an angle expressed "
   "in radians.") {
 
-  double rad;
+  double rad = 0;
   if (!validateNumeric(vm, ARG(1), &rad, "Argument 1")) return;
   RET(VAR_NUM(tan(rad)));
 }
@@ -985,7 +985,7 @@ DEF(stdMathSinh,
   "sinh(val) -> val\n"
   "Return the hyperbolic sine value of the argument [val].") {
 
-  double val;
+  double val = 0;
   if (!validateNumeric(vm, ARG(1), &val, "Argument 1")) return;
   RET(VAR_NUM(sinh(val)));
 }
@@ -994,7 +994,7 @@ DEF(stdMathCosh,
   "cosh(val) -> val\n"
   "Return the hyperbolic cosine value of the argument [val].") {
 
-  double val;
+  double val = 0;
   if (!validateNumeric(vm, ARG(1), &val, "Argument 1")) return;
   RET(VAR_NUM(cosh(val)));
 }
@@ -1003,7 +1003,7 @@ DEF(stdMathTanh,
   "tanh(val) -> val\n"
   "Return the hyperbolic tangent value of the argument [val].") {
 
-  double val;
+  double val = 0;
   if (!validateNumeric(vm, ARG(1), &val, "Argument 1")) return;
   RET(VAR_NUM(tanh(val)));
 }
@@ -1013,7 +1013,7 @@ DEF(stdMathArcSine,
   "Return the arcsine value of the argument [num] which is an angle "
   "expressed in radians.") {
 
-  double num;
+  double num = 0;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
 
   if (num < -1 || 1 < num) {
@@ -1028,7 +1028,7 @@ DEF(stdMathArcCosine,
   "Return the arc cosine value of the argument [num] which is "
   "an angle expressed in radians.") {
 
-  double num;
+  double num = 0;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
 
   if (num < -1 || 1 < num) {
@@ -1043,7 +1043,7 @@ DEF(stdMathArcTangent,
   "Return the arc tangent value of the argument [num] which is "
   "an angle expressed in radians.") {
 
-  double num;
+  double num = 0;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   RET(VAR_NUM(atan(num)));
 }
@@ -1052,7 +1052,7 @@ DEF(stdMathLog10,
   "log10(value:num) -> num\n"
   "Return the logarithm to base 10 of argument [value]") {
 
-  double num;
+  double num = 0;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   RET(VAR_NUM(log10(num)));
 }
@@ -1061,7 +1061,7 @@ DEF(stdMathRound,
   "round(value:num) -> num\n"
   "Round to nearest integer, away from zero and return the number.") {
 
-  double num;
+  double num = 0;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   RET(VAR_NUM(round(num)));
 }
@@ -1237,7 +1237,7 @@ void initializeCore(PKVM* vm) {
 #define RIGHT_OPERAND "Right operand"
 
 Var varAdd(PKVM* vm, Var v1, Var v2) {
-  double d1, d2;
+  double d1 = 0, d2 = 0;
 
   if (isNumeric(v1, &d1)) {
     if (validateNumeric(vm, v2, &d2, RIGHT_OPERAND)) {
@@ -1280,7 +1280,7 @@ Var varAdd(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varSubtract(PKVM* vm, Var v1, Var v2) {
-  double d1, d2;
+  double d1 = 0, d2 = 0;
 
   if (isNumeric(v1, &d1)) {
     if (validateNumeric(vm, v2, &d2, RIGHT_OPERAND)) {
@@ -1294,7 +1294,7 @@ Var varSubtract(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varMultiply(PKVM* vm, Var v1, Var v2) {
-  double d1, d2;
+  double d1 = 0, d2 = 0;
 
   if (isNumeric(v1, &d1)) {
     if (validateNumeric(vm, v2, &d2, RIGHT_OPERAND)) {
@@ -1308,7 +1308,7 @@ Var varMultiply(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varDivide(PKVM* vm, Var v1, Var v2) {
-  double d1, d2;
+  double d1 = 0, d2 = 0;
 
   if (isNumeric(v1, &d1)) {
     if (validateNumeric(vm, v2, &d2, RIGHT_OPERAND)) {
@@ -1322,7 +1322,7 @@ Var varDivide(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varModulo(PKVM* vm, Var v1, Var v2) {
-  double d1, d2;
+  double d1 = 0, d2 = 0;
 
   if (isNumeric(v1, &d1)) {
     if (validateNumeric(vm, v2, &d2, RIGHT_OPERAND)) {
@@ -1341,7 +1341,7 @@ Var varModulo(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varBitAnd(PKVM* vm, Var v1, Var v2) {
-  int64_t i1, i2;
+  int64_t i1 = 0, i2 = 0;
 
   if (isInteger(v1, &i1)) {
     if (validateInteger(vm, v2, &i2, RIGHT_OPERAND)) {
@@ -1355,7 +1355,7 @@ Var varBitAnd(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varBitOr(PKVM* vm, Var v1, Var v2) {
-  int64_t i1, i2;
+  int64_t i1 = 0, i2 = 0;
 
   if (isInteger(v1, &i1)) {
     if (validateInteger(vm, v2, &i2, RIGHT_OPERAND)) {
@@ -1369,7 +1369,7 @@ Var varBitOr(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varBitXor(PKVM* vm, Var v1, Var v2) {
-  int64_t i1, i2;
+  int64_t i1 = 0, i2 = 0;
 
   if (isInteger(v1, &i1)) {
     if (validateInteger(vm, v2, &i2, RIGHT_OPERAND)) {
@@ -1383,7 +1383,7 @@ Var varBitXor(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varBitLshift(PKVM* vm, Var v1, Var v2) {
-  int64_t i1, i2;
+  int64_t i1 = 0, i2 = 0;
 
   if (isInteger(v1, &i1)) {
     if (validateInteger(vm, v2, &i2, RIGHT_OPERAND)) {
@@ -1397,7 +1397,7 @@ Var varBitLshift(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varBitRshift(PKVM* vm, Var v1, Var v2) {
-  int64_t i1, i2;
+  int64_t i1 = 0, i2 = 0;
 
   if (isInteger(v1, &i1)) {
     if (validateInteger(vm, v2, &i2, RIGHT_OPERAND)) {
@@ -1411,13 +1411,13 @@ Var varBitRshift(PKVM* vm, Var v1, Var v2) {
 }
 
 Var varBitNot(PKVM* vm, Var v) {
-  int64_t i;
+  int64_t i = 0;
   if (!validateInteger(vm, v, &i, "Unary operand")) return VAR_NULL;
   return VAR_NUM((double)(~i));
 }
 
 bool varGreater(Var v1, Var v2) {
-  double d1, d2;
+  double d1 = 0, d2 = 0;
 
   if (isNumeric(v1, &d1) && isNumeric(v2, &d2)) {
     return d1 > d2;
@@ -1428,7 +1428,7 @@ bool varGreater(Var v1, Var v2) {
 }
 
 bool varLesser(Var v1, Var v2) {
-  double d1, d2;
+  double d1 = 0, d2 = 0;
 
   if (isNumeric(v1, &d1) && isNumeric(v2, &d2)) {
     return d1 < d2;
@@ -1799,7 +1799,7 @@ Var varGetSubscript(PKVM* vm, Var on, Var key) {
   switch (obj->type) {
     case OBJ_STRING:
     {
-      int64_t index;
+      int64_t index = 0;
       String* str = ((String*)obj);
       if (!validateInteger(vm, key, &index, "List index")) {
         return VAR_NULL;
@@ -1813,7 +1813,7 @@ Var varGetSubscript(PKVM* vm, Var on, Var key) {
 
     case OBJ_LIST:
     {
-      int64_t index;
+      int64_t index = 0;
       pkVarBuffer* elems = &((List*)obj)->elements;
       if (!validateInteger(vm, key, &index, "List index")) {
         return VAR_NULL;
@@ -1873,7 +1873,7 @@ void varsetSubscript(PKVM* vm, Var on, Var key, Var value) {
 
     case OBJ_LIST:
     {
-      int64_t index;
+      int64_t index = 0;
       pkVarBuffer* elems = &((List*)obj)->elements;
       if (!validateInteger(vm, key, &index, "List index")) return;
       if (!validateIndex(vm, index, elems->count, "List")) return;


### PR DESCRIPTION
I've seen #103 and I decided to try and fix some warnings.
First I added `-Wall -Wextra` to the debug compiler flags. The first warnings were just some non-initialized variables and the creation of some string.
There are some `-Wtype-limits` warning generated by the `ASSERT_INDEX` macro, as I explained in the last commit message. In short: some times that macro is called with unsigned types which by definition can't be less than 0. I disabled that warning just for the macro and now it looks ok.
I'm not sure if there is more to do for MSVC, I don't have a windows installation to try this on. In case let me now.

This is my really first contribution and I'm open to any advice, let me now! :)