### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ All benchmarks below were executed on: Windows10 (64bit), ASUS N552VX, Intel Cor
 with 12GB SODIMM Ram. And the language versions are: pocketlang (pre-alpha), wren v0.3.0,
 python v3.7.4, ruby v2.7.2.
 
-![preformance](https://user-images.githubusercontent.com/41085900/120123257-6f043280-c1cb-11eb-8c20-a42153268a0f.png)
+![performance](https://user-images.githubusercontent.com/41085900/120123257-6f043280-c1cb-11eb-8c20-a42153268a0f.png)
 
 The source files used to run benchmarks can be found at `test/benchmarks/`
 directory. They were executed using a small python script in the test directory.

--- a/cli/modules.c
+++ b/cli/modules.c
@@ -369,7 +369,7 @@ static void _fileRead(PKVM* vm) {
     return;
   }
 
-  // TODO: this is temproary.
+  // TODO: this is temporary.
   char buff[2048];
   fread((void*)buff, sizeof(char), sizeof(buff), file->fp);
   pkReturnString(vm, (const char*)buff);

--- a/src/pk_compiler.c
+++ b/src/pk_compiler.c
@@ -427,7 +427,7 @@ static void reportError(Compiler* compiler, const char* file, int line,
   vm->config.error_fn(vm, PK_ERROR_COMPILE, file, line, message);
 }
 
-// Error caused at the middle of lexing (and TK_ERROR will be lexed insted).
+// Error caused at the middle of lexing (and TK_ERROR will be lexed instead).
 static void lexError(Compiler* compiler, const char* fmt, ...) {
   va_list args;
   va_start(args, fmt);
@@ -442,7 +442,7 @@ static void parseError(Compiler* compiler, const char* fmt, ...) {
 
   Token* token = &compiler->previous;
 
-  // Lex errors would repored earlier by lexError and lexed a TK_ERROR token.
+  // Lex errors would reported earlier by lexError and lexed a TK_ERROR token.
   if (token->type == TK_ERROR) return;
 
   va_list args;
@@ -1898,7 +1898,7 @@ static void emitAssignment(Compiler* compiler, TokenType assignment) {
 
 static void emitFunctionEnd(Compiler* compiler) {
 
-  // Don't use emitOpcode(compiler, OP_RETURN); Because it'll recude the stack
+  // Don't use emitOpcode(compiler, OP_RETURN); Because it'll reduce the stack
   // size by -1, (return value will be popped). We really don't have to pop the
   // return value of the function, when returning from the end of the function,
   // because there'll always be a null value at the base of the current call
@@ -2635,9 +2635,9 @@ static void compileForStatement(Compiler* compiler) {
 // variable declaration, which will be handled.
 static void compileStatement(Compiler* compiler) {
 
-  // is_temproary will be set to true if the statement is an temporary
+  // is_temporary will be set to true if the statement is an temporary
   // expression, it'll used to be pop from the stack.
-  bool is_temproary = false;
+  bool is_temporary = false;
 
   // This will be set to true if the statement is an expression. It'll used to
   // print it's value when running in REPL mode.
@@ -2718,7 +2718,7 @@ static void compileStatement(Compiler* compiler) {
     consumeEndStatement(compiler);
 
     is_expression = true;
-    if (!compiler->new_local) is_temproary = true;
+    if (!compiler->new_local) is_temporary = true;
 
     compiler->new_local = false;
   }
@@ -2730,7 +2730,7 @@ static void compileStatement(Compiler* compiler) {
     emitOpcode(compiler, OP_REPL_PRINT);
   }
 
-  if (is_temproary) emitOpcode(compiler, OP_POP);
+  if (is_temporary) emitOpcode(compiler, OP_POP);
 }
 
 // Compile statements that are only valid at the top level of the script. Such

--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -561,7 +561,7 @@ DEF(coreHex,
     RET(VAR_NULL);
   }
 
-  // TODO: spritnf limits only to 8 character hex value, we need to do it
+  // TODO: sprintf limits only to 8 character hex value, we need to do it
   // outself for a maximum of 16 character long (see bin() for reference).
   uint32_t _x = (uint32_t)((value < 0) ? -value : value);
   int length = sprintf(ptr, "%x", _x);
@@ -1486,7 +1486,7 @@ bool varContains(PKVM* vm, Var elem, Var container) {
   UNREACHABLE();
 }
 
-// TODO: The ERR_NO_ATTRIB() macro should splited into 2 to for setter and
+// TODO: The ERR_NO_ATTRIB() macro should splitted into 2 to for setter and
 // getter and for the setter, the error message should be "object has no
 // mutable attribute", to indicate that there might be an attribute with the
 // name might be exists (but not accessed in a setter).

--- a/src/pk_opcodes.h
+++ b/src/pk_opcodes.h
@@ -33,7 +33,7 @@ OPCODE(PUSH_FALSE, 0, 1)
 OPCODE(SWAP, 0, 0)
 
 // Push a new list to construct from literal.
-// param: 2 bytes list size (defalt is 0).
+// param: 2 bytes list size (default is 0).
 OPCODE(PUSH_LIST, 2, 1)
 
 // Push a new map to construct from literal.

--- a/src/pk_vm.h
+++ b/src/pk_vm.h
@@ -110,7 +110,7 @@ struct PKVM {
   // Current compiler reference to mark it's heap allocated objects. Note that
   // The compiler isn't heap allocated. It'll be a link list of all the
   // compiler we have so far. A new compiler will be created and appended when
-  // a new scirpt is being imported and compiled at compiletime.
+  // a new script is being imported and compiled at compiletime.
   Compiler* compiler;
 
   // A cache of the compiled scripts with their path as key and the Scrpit

--- a/tests/benchmarks/benchmarks.py
+++ b/tests/benchmarks/benchmarks.py
@@ -142,7 +142,7 @@ COLORS = {
   'END'       : '\033[0m' ,
 }
 
-## Prints a warning message to stdour.
+## Prints a warning message to stdout.
 def print_warning(msg):
   os.system('') ## This will enable ANSI codes in windows terminal.
   for line in msg.splitlines():


### PR DESCRIPTION
There are small typos in:
- README.md
- cli/modules.c
- src/pk_compiler.c
- src/pk_core.c
- src/pk_opcodes.h
- src/pk_vm.h
- tests/benchmarks/benchmarks.py

Fixes:
- Should read `temporary` rather than `temproary`.
- Should read `stdout` rather than `stdour`.
- Should read `sprintf` rather than `spritnf`.
- Should read `splitted` rather than `splited`.
- Should read `script` rather than `scirpt`.
- Should read `reported` rather than `repored`.
- Should read `reduce` rather than `recude`.
- Should read `performance` rather than `preformance`.
- Should read `instead` rather than `insted`.
- Should read `default` rather than `defalt`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md