### PR TITLE
un used functions were removed

### DIFF
--- a/src/pk_vm.c
+++ b/src/pk_vm.c
@@ -439,32 +439,6 @@ static void* defaultRealloc(void* memory, size_t new_size, void* user_data) {
   return realloc(memory, new_size);
 }
 
-// If failed to resolve it'll return false. Parameter [result] should be points
-// to the string which is the path that has to be resolved and once it resolved
-// the provided result's string's on_done() will be called and, it's string
-// will be updated with the new resolved path string.
-static inline bool resolveScriptPath(PKVM* vm, PkStringPtr* path_string) {
-  if (vm->config.resolve_path_fn == NULL) return true;
-
-  const char* path = path_string->string;
-  PkStringPtr resolved;
-
-  Fiber* fiber = vm->fiber;
-  if (fiber == NULL || fiber->frame_count <= 0) {
-    // fiber == NULL => vm haven't started yet and it's a root script.
-    resolved = vm->config.resolve_path_fn(vm, NULL, path);
-  } else {
-    const Function* fn = fiber->frames[fiber->frame_count - 1].fn;
-    resolved = vm->config.resolve_path_fn(vm, fn->owner->path->data, path);
-  }
-
-  // Done with the last string and update it with the new string.
-  if (path_string->on_done != NULL) path_string->on_done(vm, *path_string);
-  *path_string = resolved;
-
-  return path_string->string != NULL;
-}
-
 // Import and return Script object as Var. If the script is imported and
 // compiled here it'll set [is_new_script] to true otherwise (using the cached
 // script) set to false.

--- a/tests/lang/basics.pk
+++ b/tests/lang/basics.pk
@@ -50,6 +50,15 @@ if a and b then assert(false) end
 if a or b then val = 42 else assert(false) end assert(val == 42)
 if get_true() or false then val = 12 end assert(val == 12)
 
+## Newer logical or implementation.
+## a or b  === if (a) return a else return b
+## a and b === if (!a) return a else return b
+a = null; b = [1, 2, 3]
+assert((a or b) == [1, 2, 3]) ## Note == has higher precedence than and/or.
+assert((a and b) == null)
+assert((b or a) == [1, 2, 3])
+assert((a or b) == b or a)
+
 ## Recursive to_string list/map
 l = [1]
 list_append(l, l)

--- a/tests/lang/functions.pk
+++ b/tests/lang/functions.pk
@@ -14,14 +14,12 @@ end
 assert(val == 'defined after the call')
 
 ## Chain call tests. (concatenative programming)
-
-def fn1(data) return '[fn1:' + data + ']' end
-def fn2(data, suffix) return '[fn2:' + data + '|' + suffix + ']' end
-def fn3(data) return '[fn3:' + data + ']' end
-
-result = 'data' -> fn1 -> fn2{'suff'} -> fn3
-assert(result == '[fn3:[fn2:[fn1:data]|suff]]')
-
+## Chain call no more supported (unnecessary feature).
+#def fn1(data) return '[fn1:' + data + ']' end
+#def fn2(data, suffix) return '[fn2:' + data + '|' + suffix + ']' end
+#def fn3(data) return '[fn3:' + data + ']' end
+#result = 'data' -> fn1 -> fn2{'suff'} -> fn3
+#assert(result == '[fn3:[fn2:[fn1:data]|suff]]')
 # str_lower(s) function refactored to s.lower attribute.
 #result = ' tEST+InG ' -> str_strip -> str_lower
 #assert(result == 'test+ing')

--- a/tests/lang/import.pk
+++ b/tests/lang/import.pk
@@ -11,7 +11,7 @@ from path import *
 
 import "basics.pk" ## will import all
 import "controlflow.pk" as if_test
-from "functions.pk" import fn1, fn2 as f2, fn3
+from "functions.pk" import f1, f2 as fn2, f3
 
 import "class.pk" as class_
 assert(class_.Vec(42, 3.14).y == 3.14)

--- a/tests/lang/toc.pk
+++ b/tests/lang/toc.pk
@@ -71,6 +71,11 @@ for i in 0..100
   assert(i%2 == f(i))
 end
 
+## The below function caused a bug after compile time stack size calculation
+## bug fixed. Added here to check for regression.
+def h()
+  f() ## <-- Not tail called here (anymore) because it's not returned.
+end
 
 # If we got here, that means all test were passed.
 print('All TESTS PASSED')


### PR DESCRIPTION
- removed function `resolveScriptPath()` which not being used anymore (as mentioned https://github.com/ThakeeNathees/pocketlang/pull/162#issuecomment-877810068)
- Chain call operator is removed.
- In addition, tail call is not enabled for functions that doesn't return the last call (caused a bug).