### PR TITLE
String interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ end
 
 # Prints all fibonacci from 0 to 10 exclusive.
 for i in 0..10
-  print(fib(i))
+  print("fib($i) = ${fib(i)}")
 end
 ```
 

--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -730,6 +730,30 @@ DEF(coreListAppend,
   RET(VAR_OBJ(list));
 }
 
+// TODO: currently it takes one argument (to test string interpolation).
+//       Add join delimeter as an optional argument.
+DEF(coreListJoin,
+  "list_join(self:List) -> String\n"
+  "Concatinate the elements of the list and return as a string.") {
+
+  List* list;
+  if (!validateArgList(vm, 1, &list)) return;
+
+  pkByteBuffer buff;
+  pkByteBufferInit(&buff);
+
+  for (int i = 0; i < list->elements.count; i++) {
+    String* elem = toString(vm, list->elements.data[i]);
+    vmPushTempRef(vm, &elem->_super); // elem
+    pkByteBufferAddString(&buff, vm, elem->data, elem->length);
+    vmPopTempRef(vm);
+  }
+
+  String* str = newStringLength(vm, (const char*)buff.data, buff.count);
+  pkByteBufferClear(&buff, vm);
+  RET(VAR_OBJ(str));
+}
+
 // Map functions.
 // --------------
 
@@ -1259,6 +1283,7 @@ void initializeCore(PKVM* vm) {
 
   // List functions.
   INITIALIZE_BUILTIN_FN("list_append", coreListAppend, 2);
+  INITIALIZE_BUILTIN_FN("list_join",   coreListJoin,   1);
 
   // Map functions.
   INITIALIZE_BUILTIN_FN("map_remove",  coreMapRemove,  2);

--- a/tests/lang/basics.pk
+++ b/tests/lang/basics.pk
@@ -137,5 +137,18 @@ assert(.5 == 0.5)
 assert(.333 == .333)
 assert(.1 + 1 == 1.1)
 
+def getLength(test)
+  assert(test == "test")
+  return 4
+end
+assert("${getLength('${"test"}')}" == "${2 + 2}")
+
+name = "World"
+assert("Hello $name!" == "Hello World!")
+b = 'vb'; d = 'vd'; f = 'vf'
+assert("a ${ b + ' c ${d + " e ${f}"}' }" == "a vb c vd e vf")
+assert("$b$d$f" == "vbvdvf")
+
+
 # If we got here, that means all test were passed.
 print('All TESTS PASSED')

--- a/tests/lang/builtin_fn.pk
+++ b/tests/lang/builtin_fn.pk
@@ -1,0 +1,7 @@
+
+## TODO: add more test of built in functions.
+
+assert(list_join([1, 2, 3]) == "123")
+assert(list_join(["hello", " world"]) == "hello world")
+assert(list_join([[], []]) == "[][]")
+

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -16,6 +16,7 @@ THIS_PATH = abspath(dirname(__file__))
 TEST_SUITE = {
   "Unit Tests": (
     "lang/basics.pk",
+    "lang/builtin_fn.pk",
     "lang/class.pk",
     "lang/core.pk",
     "lang/controlflow.pk",


### PR DESCRIPTION
closes: #171

- The syntax is similar to Kotlin's string interpolation.
- Supports up to 8 nested interpolation levels.
- Support for both single and double-quoted strings.

## Ex: `"Hello $name"`, `"e = ${m * pow(c, 2)}"`

```ruby
from math import sqrt

for i in 0..5
  print("sqrt($i) = ${sqrt(i)}")
end
```

output

```
sqrt(0) = 0
sqrt(1) = 1
sqrt(2) = 1.414213562373095
sqrt(3) = 1.732050807568877
sqrt(4) = 2
```