### PR TITLE
literals renamed to constants

### DIFF
--- a/src/pk_compiler.c
+++ b/src/pk_compiler.c
@@ -1958,7 +1958,7 @@ static void compilerAddForward(Compiler* compiler, int instruction, Fn* fn,
 
 // Add a literal constant to scripts literals and return it's index.
 static int compilerAddConstant(Compiler* compiler, Var value) {
-  pkVarBuffer* literals = &compiler->script->literals;
+  pkVarBuffer* literals = &compiler->script->constants;
 
   for (uint32_t i = 0; i < literals->count; i++) {
     if (isValuesSame(literals->data[i], value)) {
@@ -2665,12 +2665,12 @@ static void compileRegularImport(Compiler* compiler) {
       // If it has a module name use it as binding variable.
       // Core libs names are it's module name but for local libs it's optional
       // to define a module name for a script.
-      if (lib && lib->module != NULL) {
+      if (lib && lib->name != NULL) {
 
         // Get the variable to bind the imported symbol, if we already have a
         // variable with that name override it, otherwise use a new variable.
-        const char* name = lib->module->data;
-        uint32_t length = lib->module->length;
+        const char* name = lib->name->data;
+        uint32_t length = lib->name->length;
         int line = compiler->parser.previous.line;
         var_index = compilerImportName(compiler, line, name, length);
 
@@ -3015,14 +3015,14 @@ PkResult compile(PKVM* vm, Script* script, const char* source,
     // If the script running a REPL or compiled multiple times by hosting
     // application module attribute might already set. In that case make it
     // Compile error.
-    if (script->module != NULL) {
+    if (script->name != NULL) {
       parseError(compiler, "Module name already defined.");
 
     } else {
       consume(compiler, TK_NAME, "Expected a name for the module.");
       const char* name = compiler->parser.previous.start;
       uint32_t len = compiler->parser.previous.length;
-      script->module = newStringLength(vm, name, len);
+      script->name = newStringLength(vm, name, len);
       consumeEndStatement(compiler);
     }
   }

--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -820,13 +820,13 @@ static inline void assertModuleNameDef(PKVM* vm, Script* script,
   // Check if function with the same name already exists.
   if (scriptGetFunc(script, name, (uint32_t)strlen(name)) != -1) {
     __ASSERT(false, stringFormat(vm, "A function named '$' already esists "
-      "on module '@'", name, script->module)->data);
+      "on module '@'", name, script->name)->data);
   }
 
   // Check if a global variable with the same name already exists.
   if (scriptGetGlobals(script, name, (uint32_t)strlen(name)) != -1) {
     __ASSERT(false, stringFormat(vm, "A global variable named '$' already "
-      "esists on module '@'", name, script->module)->data);
+      "esists on module '@'", name, script->name)->data);
   }
 }
 

--- a/src/pk_debug.c
+++ b/src/pk_debug.c
@@ -107,8 +107,8 @@ void dumpFunctionCode(PKVM* vm, Function* func) {
       case OP_PUSH_CONSTANT:
       {
         int index = READ_SHORT();
-        ASSERT_INDEX((uint32_t)index, func->owner->literals.count);
-        Var value = func->owner->literals.data[index];
+        ASSERT_INDEX((uint32_t)index, func->owner->constants.count);
+        Var value = func->owner->constants.data[index];
 
         // Prints: %5d [val]\n
         PRINT_INT(index);

--- a/src/pk_value.h
+++ b/src/pk_value.h
@@ -276,19 +276,35 @@ struct Range {
 struct Script {
   Object _super;
 
-  // For core libraries the module and the path are same and points to the
+  // For core libraries the name and the path are same and points to the
   // same String objects.
-  String* module; //< Module name of the script.
-  String* path;   //< Path of the script.
+  String* name; //< The name of the module (defined with module keyword).
+  String* path; //< Path of the script.
 
-  pkVarBuffer globals;         //< Script level global variables.
-  pkUintBuffer global_names;   //< Name map to index in globals.
+  // The constant pool of the module, which contains literal values like
+  // numbers, strings, and functions which are considered constants to
+  // a moduel as well as classes.
+  pkVarBuffer constants;
+
+  // All the variable names, globals name, attribute name etc, are stored in
+  // the [names] buffer. They can be stored in the constants but to make it
+  // more clear different between string literal and names they're stored in
+  // a different location.
+  pkStringBuffer names;
+
+  // TODO:
+  // Consider merging names and constants. Java's class file doesn't have
+  // a seperation between string literals and names in it's constant pool.
+
+  // Globals is an array of global variables of the module. All the names
+  // (including global variables) are stored in the names buffer of the script
+  // (defined bellow). The (i)th global variables names is located at index (j)
+  // in the names buffer where j = global_names[i].
+  pkVarBuffer globals;
+  pkUintBuffer global_names;
 
   pkFunctionBuffer functions;  //< Functions of the script.
   pkClassBuffer classes;       //< Classes of the script.
-
-  pkStringBuffer names;        //< Name literals, attribute names, etc.
-  pkVarBuffer literals;        //< Script literal constant values.
 
   Function* body;              //< Script body is an anonymous function.
 
@@ -310,7 +326,12 @@ struct Function {
 
   const char* name; //< Name in the script [owner] or C literal.
   Script* owner;    //< Owner script of the function.
-  int arity;        //< Number of argument the function expects.
+
+  // Number of argument the function expects. If the arity is -1 that means
+  // the function has a variadic number of parameters. When a function is
+  // constructed the value for arity is set to -2 to indicate that it hasn't
+  // initialized.
+  int arity;
 
   // Number of upvalues it uses, we're defining it here (and not in object Fn)
   // is prevent checking is_native everytime (which might be a bit faster).
@@ -539,7 +560,7 @@ Class* newClass(PKVM* vm, Script* scr, const char* name, uint32_t length);
 // Allocate new instance with of the base [type]. Note that if [initialize] is
 // false, the field value buffer of the instance would be un initialized (ie.
 // the buffer count = 0). Otherwise they'll be set to VAR_NULL.
-Instance* newInstance(PKVM* vm, Class* ty, bool initialize);
+Instance* newInstance(PKVM* vm, Class* cls, bool initialize);
 
 // Allocate new native instance and with [data] as the native type handle and
 // return Instance*. The [id] is the unique id of the instance, this would be

--- a/src/pk_vm.c
+++ b/src/pk_vm.c
@@ -683,8 +683,8 @@ L_vm_main_loop:
     OPCODE(PUSH_CONSTANT):
     {
       uint16_t index = READ_SHORT();
-      ASSERT_INDEX(index, script->literals.count);
-      PUSH(script->literals.data[index]);
+      ASSERT_INDEX(index, script->constants.count);
+      PUSH(script->constants.data[index]);
       DISPATCH();
     }
 


### PR DESCRIPTION
Since the functions and classes will be moved to the constants buffer rather than having their own (function buffer and class buffer) the rename is essential, and to make the refactoring process easier all the intermediate steps are done with its own pr.