### PR TITLE
Scripts renamed to Modules

### DIFF
--- a/cli/internal.h
+++ b/cli/internal.h
@@ -27,7 +27,8 @@
 
 #define CLI_NOTICE                                                            \
   "PocketLang " PK_VERSION_STRING " (https://github.com/ThakeeNathees/pocketlang/)\n" \
-  "Copyright(c) 2020 - 2021 ThakeeNathees.\n"                                 \
+  "Copyright (c) 2020 - 2021 ThakeeNathees\n"                                 \
+  "Copyright (c) 2021-2022 Pocketlang Contributors\n"                         \
   "Free and open source software under the terms of the MIT license.\n"
 
  // FIXME: the vm user data of cli.

--- a/src/include/pocketlang.h
+++ b/src/include/pocketlang.h
@@ -84,7 +84,7 @@ typedef enum {
   PK_LIST,
   PK_MAP,
   PK_RANGE,
-  PK_SCRIPT,
+  PK_MODULE,
   PK_FUNCTION,
   PK_FIBER,
   PK_CLASS,

--- a/src/pk_compiler.h
+++ b/src/pk_compiler.h
@@ -25,11 +25,11 @@ typedef enum {
 typedef struct Compiler Compiler;
 
 // This will take source code as a cstring, compiles it to pocketlang bytecodes
-// and append them to the script's implicit main function ("$(SourceBody)").
-// On a successfull compilation it'll return PK_RESULT_SUCCESS, otherwise it'll
-// return PK_RESULT_COMPILE_ERROR but if repl_mode set in the [options],  and
-// we've reached and unexpected EOF it'll return PK_RESULT_UNEXPECTED_EOF.
-PkResult compile(PKVM* vm, Script* script, const char* source,
+// and append them to the module's implicit main function. On a successfull
+// compilation it'll return PK_RESULT_SUCCESS, otherwise it'll return
+// PK_RESULT_COMPILE_ERROR but if repl_mode set in the [options],  and we've
+// reached and unexpected EOF it'll return PK_RESULT_UNEXPECTED_EOF.
+PkResult compile(PKVM* vm, Module* module, const char* source,
                  const PkCompileOptions* options);
 
 // Mark the heap allocated objects of the compiler at the garbage collection

--- a/src/pk_core.h
+++ b/src/pk_core.h
@@ -25,7 +25,7 @@ const char* getBuiltinFunctionName(const PKVM* vm, int index);
 
 // Return the core library with the [name] if exists in the core libs,
 // otherwise returns NULL.
-Script* getCoreLib(const PKVM* vm, String* name);
+Module* getCoreLib(const PKVM* vm, String* name);
 
 /*****************************************************************************/
 /* OPERATORS                                                                 */

--- a/src/pk_debug.c
+++ b/src/pk_debug.c
@@ -365,11 +365,11 @@ void dumpGlobalValues(PKVM* vm) {
   int frame_ind = fiber->frame_count - 1;
   ASSERT(frame_ind >= 0, OOPS);
   CallFrame* frame = &fiber->frames[frame_ind];
-  Script* scr = frame->fn->owner;
+  Module* module = frame->fn->owner;
 
-  for (uint32_t i = 0; i < scr->global_names.count; i++) {
-    String* name = scr->names.data[scr->global_names.data[i]];
-    Var value = scr->globals.data[i];
+  for (uint32_t i = 0; i < module->global_names.count; i++) {
+    String* name = module->names.data[module->global_names.data[i]];
+    Var value = module->globals.data[i];
     printf("%10s = ", name->data);
     dumpValue(vm, value);
     printf("\n");

--- a/src/pk_vm.h
+++ b/src/pk_vm.h
@@ -46,9 +46,8 @@
     (vm->fiber->error = err);        \
   } while (false)
 
-// Builtin functions are stored in an array in the VM (unlike script functions
-// they're member of function buffer of the script) and this struct is a single
-// entry of the array.
+// Builtin functions are stored in an array in the VM unlike other functions
+// builtin function's doesn't belongs to any module.
 typedef struct {
   const char* name; //< Name of the function.
   uint32_t length;  //< Length of the name.
@@ -111,14 +110,14 @@ struct PKVM {
   // Current compiler reference to mark it's heap allocated objects. Note that
   // The compiler isn't heap allocated. It'll be a link list of all the
   // compiler we have so far. A new compiler will be created and appended when
-  // a new script is being imported and compiled at compiletime.
+  // a new module is being imported and compiled at compiletime.
   Compiler* compiler;
 
-  // A cache of the compiled scripts with their path as key and the Scrpit
+  // A cache of the compiled modules with their path as key and the Scrpit
   // object as the value.
-  Map* scripts;
+  Map* modules;
 
-  // A map of core libraries with their name as the key and the Script object
+  // A map of core libraries with their name as the key and the Module object
   // as the value.
   Map* core_libs;
 
@@ -192,9 +191,9 @@ void vmPushTempRef(PKVM* vm, Object* obj);
 // Pop the top most object from temporary reference stack.
 void vmPopTempRef(PKVM* vm);
 
-// Returns the scrpt with the resolved [path] (also the key) in the vm's script
-// cache. If not found itll return NULL.
-Script* vmGetScript(PKVM* vm, String* path);
+// Returns the module with the resolved [path] (also the key) in the VM's
+// modules cache. If not found itll return NULL.
+Module* vmGetModule(PKVM* vm, String* path);
 
 // ((Context switching - start))
 // Prepare a new fiber for execution with the given arguments. That can be used


### PR DESCRIPTION
The name script is missleading as it only refering to the scripts
(the files that contain the statements) where as it could also
be the native object.

```c
// Module in pocketlang is a collection of globals, functions, classes, and top
// level statements, that can be imported into other modules.
```

After this commit, native functions can also have set owner module
and it won't be as confusing as before.