### PR TITLE
Closures implemented

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -202,7 +202,7 @@ int main(int argc, const char** argv) {
   if (cmd != NULL) { // pocket -c "print('foo')"
 
     PkStringPtr source = { cmd, NULL, NULL, 0, 0 };
-    PkStringPtr path = { "$(Source)", NULL, NULL, 0, 0 };
+    PkStringPtr path = { "@(Source)", NULL, NULL, 0, 0 };
     PkResult result = pkInterpretSource(vm, source, path, NULL);
     exitcode = (int)result;
 

--- a/src/pk_debug.c
+++ b/src/pk_debug.c
@@ -241,6 +241,15 @@ void dumpFunctionCode(PKVM* vm, Function* func) {
         break;
       }
 
+      case OP_PUSH_UPVALUE:
+      case OP_STORE_UPVALUE:
+      {
+        int index = READ_BYTE();
+        PRINT_INT(index);
+        NEWLINE();
+        break;
+      }
+
       case OP_PUSH_CLOSURE:
       {
         int index = READ_SHORT();
@@ -256,7 +265,11 @@ void dumpFunctionCode(PKVM* vm, Function* func) {
         break;
       }
 
-      case OP_POP:    NO_ARGS(); break;
+      case OP_CLOSE_UPVALUE:
+      case OP_POP:
+        NO_ARGS();
+        break;
+
       case OP_IMPORT:
       {
         int index = READ_SHORT();

--- a/src/pk_internal.h
+++ b/src/pk_internal.h
@@ -78,7 +78,7 @@
 
 // Name of a literal function. All literal function will have the same name but
 // they're uniquely identified by their index in the script's function buffer.
-#define LITERAL_FN_NAME "@literalFn"
+#define LITERAL_FN_NAME "@func"
 
 /*****************************************************************************/
 /* ALLOCATION MACROS                                                         */

--- a/src/pk_opcodes.h
+++ b/src/pk_opcodes.h
@@ -97,10 +97,23 @@ OPCODE(STORE_GLOBAL, 1, 0)
 // params: 1 bytes index.
 OPCODE(PUSH_BUILTIN_FN, 1, 1)
 
+// Push an upvalue of the current closure at the index which is the first one
+// byte argument.
+// params: 1 byte index.
+OPCODE(PUSH_UPVALUE, 1, 1)
+
+// Store the stack top value to the upvalues of the current function's upvalues
+// array and don't pop it, since it's the result of the assignment.
+// params: 1 byte index.
+OPCODE(STORE_UPVALUE, 1, 0)
+
 // Push a closure for the function at the constant pool with index of the
 // first 2 bytes arguments.
 // params: 2 byte index.
 OPCODE(PUSH_CLOSURE, 2, 1)
+
+// Close the upvalue for the local at the stack top and pop it.
+OPCODE(CLOSE_UPVALUE, 0, -1)
 
 // Pop the stack top.
 OPCODE(POP, 0, -1)

--- a/src/pk_value.c
+++ b/src/pk_value.c
@@ -206,7 +206,7 @@ static void popMarkedObjectsInternal(Object* obj, PKVM* vm) {
       markVarBuffer(vm, &module->globals);
       vm->bytes_allocated += sizeof(Var) * module->globals.capacity;
 
-      // Integer buffer has no gray call.
+      // Integer buffer has no mark call.
       vm->bytes_allocated += sizeof(uint32_t) * module->global_names.capacity;
 
       markVarBuffer(vm, &module->constants);

--- a/src/pk_value.c
+++ b/src/pk_value.c
@@ -510,7 +510,7 @@ Fiber* newFiber(PKVM* vm, Closure* closure) {
     fiber->sp = fiber->stack + 1;
 
   } else {
-    // Allocate stack.
+    // Calculate the stack size.
     int stack_size = utilPowerOf2Ceil(closure->fn->fn->stack_size + 1);
     if (stack_size < MIN_STACK_SIZE) stack_size = MIN_STACK_SIZE;
     fiber->stack = ALLOCATE_ARRAY(vm, Var, stack_size);
@@ -528,6 +528,8 @@ Fiber* newFiber(PKVM* vm, Closure* closure) {
     fiber->frames[0].ip = closure->fn->fn->opcodes.data;
     fiber->frames[0].rbp = fiber->ret;
   }
+
+  fiber->open_upvalues = NULL;
 
   // Initialize the return value to null (doesn't really have to do that here
   // but if we're trying to debut it may crash when dumping the return value).

--- a/src/pk_value.h
+++ b/src/pk_value.h
@@ -465,6 +465,11 @@ struct Fiber {
   // The stack pointer (%rsp) pointing to the stack top.
   Var* sp;
 
+  // All the open upvalues will form a linked list in the fiber and the
+  // upvalues are sorted in the same order their locals in the stack. The
+  // bellow pointer is the head of those upvalues near the stack top.
+  Upvalue* open_upvalues;
+
   // The stack base pointer of the current frame. It'll be updated before
   // calling a native function. (`fiber->ret` === `curr_call_frame->rbp`). And
   // also updated if the stack is reallocated (that's when it's about to get

--- a/tests/lang/closure.pk
+++ b/tests/lang/closure.pk
@@ -1,0 +1,87 @@
+
+## Simple upvalue.
+def f1
+  local = "foo"
+  return func
+    return local
+  end
+end
+assert(f1()() == "foo")
+
+def add3(x)
+  return func(y)
+    return func(z)
+      return x + y + z
+    end
+  end
+end
+assert(add3(1)(2)(3) == 6);
+assert(add3(7)(6)(4) == 17);
+
+## Upvalue external to the inner function.
+def f2
+  local = "bar"
+  return func
+    fn = func
+      return local
+    end
+    return fn
+  end
+end
+assert(f2()()() == "bar")
+
+## Check if upvalues are shared between closures.
+def f3
+  local = "baz"
+  _fn1 = func(x)
+    local = x
+  end
+  _fn2 = func
+    return local
+  end
+  return [_fn1, _fn2]
+end
+fns = f3()
+fns[0]("qux")
+assert(fns[1]() == "qux")
+
+def f4
+  a = []
+  x = 10
+  for i in 0..2
+    j = i ## 'i' is shared, but 'j' doesn't
+    list_append(
+      a,
+      func
+        return x + j
+      end
+    )
+  end
+  x = 20
+  return a
+end
+a = f4()
+assert(a[0]() == 20)
+assert(a[1]() == 21)
+
+def f5
+  l1 = 12
+  return func ## c1
+    l2 = 34
+    return func ## c2
+      l3 = 56
+      return func ## c3
+        return func ## c4
+          return func ## c5
+            return l1 + l2 + l3
+          end
+        end
+      end
+    end
+  end
+end
+
+print(f5()()()()()() == 102)
+
+print('All TESTS PASSED')
+

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -18,6 +18,7 @@ TEST_SUITE = {
     "lang/basics.pk",
     "lang/builtin_fn.pk",
     "lang/class.pk",
+    "lang/closure.pk",
     "lang/core.pk",
     "lang/controlflow.pk",
     "lang/fibers.pk",


### PR DESCRIPTION
Literal functions can now capture an external local value via upvalues.

```ruby
def fn()
  local = "foo"
  return func
    return local
  end
end
assert(fn()() == "foo")

```

Upvalues are shared between all the closures that captured it.

```ruby
def fn
  local = "bar"
  _fn1 = func(val)
    local = val
  end
  _fn2 = func
    return local
  end
  return [_fn1, _fn2]
end

closures = fn()
closures[0]("baz")
assert(closures[1]() == "baz")
```

Note: the keyword for creating closures will be changed to `function` from `func` for better readability, and it's more common among many languages.