### PR TITLE
tcc build supported.

### DIFF
--- a/cli/thirdparty/argparse/argparse.c
+++ b/cli/thirdparty/argparse/argparse.c
@@ -101,11 +101,22 @@ argparse_getvalue(struct argparse *self, const struct argparse_option *opt,
     case ARGPARSE_OPT_FLOAT:
         errno = 0;
         if (self->optvalue) {
+// -- pocketlang start --
+// Not sure why but tcc cause an error "tcc: error: undefined symbol 'strtof'".
+#if defined(__TINYC__)
+            *(float*)opt->value = (float)strtod(self->optvalue, (char**)&s);
+#else
             *(float *)opt->value = strtof(self->optvalue, (char **)&s);
+#endif
             self->optvalue       = NULL;
         } else if (self->argc > 1) {
             self->argc--;
+#if defined(__TINYC__)
+            *(float*)opt->value = (float)strtod(*++self->argv, (char**)&s);
+#else
             *(float *)opt->value = strtof(*++self->argv, (char **)&s);
+#endif
+// -- pocketlang end --
         } else {
             argparse_error(self, opt, "requires a value", flags);
         }
@@ -278,10 +289,10 @@ unknown:
     }
 
 end:
-/* Modified By : https://www.github.com/ThakeeNathees */
+// -- pocketlang start --
     memmove((void*)(self->out + self->cpidx), (void*)(self->argv),
             self->argc * sizeof(*self->out));
-/* -------------------------------------------------- */
+// -- pocketlang end --
     self->out[self->cpidx + self->argc] = NULL;
 
     return self->cpidx + self->argc;
@@ -302,9 +313,9 @@ argparse_usage(struct argparse *self)
     if (self->description)
         fprintf(stdout, "%s\n", self->description);
 
-/* Modified By : https://www.github.com/ThakeeNathees */
+// -- pocketlang start --
 //    fputc('\n', stdout);
-/* -------------------------------------------------- */
+// -- pocketlang end --
 
     const struct argparse_option *options;
 

--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -1089,82 +1089,6 @@ DEF(stdMathRound,
   RET(VAR_NUM(round(num)));
 }
 
-DEF(stdMathLog2,
-  "log2(value:num) -> num\n"
-  "Returns the logarithm to base 2 of the argument [value]") {
-
-  double num;
-  if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
-  RET(VAR_NUM(log2(num)));
-}
-
-DEF(stdMathHypot,
-  "hypot(x:num,y:num) -> num\n"
-  "Returns the hypotenuse of a right-angled triangle with side [x] and [y]") {
-
-  double x, y;
-  if (!validateNumeric(vm, ARG(1), &x, "Argument 1")) return;
-  if (!validateNumeric(vm, ARG(2), &y, "Argument 2")) return;
-  RET(VAR_NUM(hypot(x, y)));
-}
-
-DEF(stdMathCbrt,
-  "cbrt(value:num) -> num\n"
-  "Returns the cuberoot of argument [value]") {
-
-  double num;
-  if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
-  RET(VAR_NUM(cbrt(num)));
-}
-
-DEF(stdMathGamma,
-  "gamma(value:num) -> num\n"
-  "Returns the gamma function of argument [value]") {
-
-  double num;
-  if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
-  RET(VAR_NUM(tgamma(num)));
-}
-
-// TODO: This makes the pocket source code not portable.
-#if defined(__USE_GNU) || defined(__USE_BSD)
-DEF(stdMathGamma,
-  "gamma(value:num) -> num\n"
-  "Returns the gamma function of argument [value]") {
-
-  double num;
-  if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
-  RET(VAR_NUM(gamma(num)));
-}
-#endif
-
-DEF(stdMathLgamma,
-  "lgamma(value:num) -> num\n"
-  "Returns the complementary gamma function of argument [value]") {
-
-  double num;
-  if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
-  RET(VAR_NUM(lgamma(num)));
-}
-
-DEF(stdMathErf,
-  "erf(value:num) -> num\n"
-  "Returns the error function of argument [value]") {
-
-  double num;
-  if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
-  RET(VAR_NUM(erf(num)));
-}
-
-DEF(stdMathErfc,
-  "erfc(value:num) -> num\n"
-  "Returns the complementary error function of argument [value]") {
-
-  double num;
-  if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
-  RET(VAR_NUM(erfc(num)));
-}
-
 // 'Fiber' module methods.
 // -----------------------
 
@@ -1259,13 +1183,6 @@ static void initializeCoreModules(PKVM* vm) {
   MODULE_ADD_FN(math, "atan",   stdMathArcTangent, 1);
   MODULE_ADD_FN(math, "log10",  stdMathLog10,      1);
   MODULE_ADD_FN(math, "round",  stdMathRound,      1);
-  MODULE_ADD_FN(math, "log2",   stdMathLog2,       1);
-  MODULE_ADD_FN(math, "hypot",  stdMathHypot,      2);
-  MODULE_ADD_FN(math, "cbrt",   stdMathCbrt,       1);
-  MODULE_ADD_FN(math, "gamma",  stdMathGamma,      1);
-  MODULE_ADD_FN(math, "lgamma", stdMathLgamma,     1);
-  MODULE_ADD_FN(math, "erf",    stdMathErf,        1);
-  MODULE_ADD_FN(math, "erfc",   stdMathErfc,       1);
 
   // Note that currently it's mutable (since it's a global variable, not
   // constant and pocketlang doesn't support constant) so the user shouldn't

--- a/tests/lang/core.pk
+++ b/tests/lang/core.pk
@@ -84,19 +84,21 @@ assert(round(1.4) == 1)
 assert(round(1.5) == 2)
 assert(round(-1.5) == -2)
 
-assert(abs(log2(2) - 1) < threshold)
-assert(abs(log2(1) - 0) < threshold)
-assert(abs(log2(5) - 2.321928094887362) < threshold)
-
-assert(abs(hypot(1,1) - 1.414213562373095) < threshold)
-assert(abs(hypot(3,5) - 5.830951894845301) < threshold)
-
-assert(abs(cbrt(27) - 3) < threshold)
-assert(abs(cbrt(9) - 2.080083823051904) < threshold)
-
-assert(abs(gamma(5) - 24) < threshold)
-assert(abs(gamma(2.2) - 1.101802490879713) < threshold)
-
+## Note that these mathe functions are removed temproarly from the core
+## For more information see PR #201
+##
+##assert(abs(log2(2) - 1) < threshold)
+##assert(abs(log2(1) - 0) < threshold)
+##assert(abs(log2(5) - 2.321928094887362) < threshold)
+##
+##assert(abs(hypot(1,1) - 1.414213562373095) < threshold)
+##assert(abs(hypot(3,5) - 5.830951894845301) < threshold)
+##
+##assert(abs(cbrt(27) - 3) < threshold)
+##assert(abs(cbrt(9) - 2.080083823051904) < threshold)
+##
+##assert(abs(gamma(5) - 24) < threshold)
+##assert(abs(gamma(2.2) - 1.101802490879713) < threshold)
 
 
 


### PR DESCRIPTION
in order to support tcc, I need to remove some math functions that
tcc on windows doesn't support (v language is using [openlibm](https://github.com/JuliaMath/openlibm)).
This is temporary and the math functions should be moved to its
own math script library once the import system is refactored.

TCC build tested with the binary downloaded from --
https://download.savannah.gnu.org/releases/tinycc/tcc-0.9.27-win64-bin.zip
(download link from the https://bellard.org/tcc/ website), and this
should be added to the CI workflow (something like below).

```
curl -L https://download.savannah.gnu.org/releases/tinycc/tcc-0.9.27-win64-bin.zip --output tcc.zip
unzip tcc.zip
git clone --single-branch --depth=1 https://github.com/ThakeeNathees/pocketlang.git
tcc/tcc.exe -o pocket.exe -Ipocketlang/src/include pocketlang/cli/*.c pocketlang/src/*.c
pocket.exe --version
```
