### PR TITLE
More refactors

### DIFF
--- a/cli/all.c
+++ b/cli/all.c
@@ -23,6 +23,7 @@
 /*****************************************************************************/
 
 // Library : cwalk
+// License : MIT
 // Source  : https://github.com/likle/cwalk/
 // Doc     : https://likle.github.io/cwalk/
 // About   : Path library for C/C++. Cross-Platform for Windows, MacOS and
@@ -30,6 +31,19 @@
 #include "modules/thirdparty/cwalk/cwalk.c"
 
 // Library : argparse
+// License : MIT
 // Source  : https://github.com/cofyc/argparse/
 // About   : Command-line arguments parsing library.
 #include "thirdparty/argparse/argparse.c"
+
+// Library : dlfcn-win32
+// License : MIT
+// Source  : https://github.com/dlfcn-win32/dlfcn-win32/
+// About   :  An implementation of dlfcn for Windows.
+#ifdef _WIN32
+// FIXME:
+// This library redefine the malloc family macro, which cause a compile
+// time warning.
+//
+//  #include "modules/thirdparty/dlfcn-win32/dlfcn.c"
+#endif

--- a/cli/modules/std_file.c
+++ b/cli/modules/std_file.c
@@ -141,5 +141,6 @@ void registerModuleFile(PKVM* vm) {
   pkModuleAddFunction(vm, file, "write", _fileWrite, 2);
   pkModuleAddFunction(vm, file, "close", _fileClose, 1);
 
+  pkRegisterModule(vm, file);
   pkReleaseHandle(vm, file);
 }

--- a/cli/modules/std_path.c
+++ b/cli/modules/std_path.c
@@ -233,5 +233,6 @@ void registerModulePath(PKVM* vm) {
   pkModuleAddFunction(vm, path, "isfile",    _pathIsFile,       1);
   pkModuleAddFunction(vm, path, "isdir",     _pathIsDir,        1);
 
+  pkRegisterModule(vm, path);
   pkReleaseHandle(vm, path);
 }

--- a/cli/native.py
+++ b/cli/native.py
@@ -18,6 +18,7 @@ PK_API = "pk_api"
 PK_API_TYPE = "PkNativeApi"
 API_DEF = f'''\
 static {PK_API_TYPE} {PK_API};
+
 void pkInitApi({PK_API_TYPE}* api) {{%s
 }}
 '''

--- a/cli/thirdparty/argparse/argparse.c
+++ b/cli/thirdparty/argparse/argparse.c
@@ -102,7 +102,8 @@ argparse_getvalue(struct argparse *self, const struct argparse_option *opt,
         errno = 0;
         if (self->optvalue) {
 // -- pocketlang start --
-// Not sure why but tcc cause an error "tcc: error: undefined symbol 'strtof'".
+// tcc cause an error "tcc: error: undefined symbol 'strtof'" on Windows since
+// it depend on the libm. Maybe I should add _WIN32 marcro along with it.
 #if defined(__TINYC__)
             *(float*)opt->value = (float)strtod(self->optvalue, (char**)&s);
 #else

--- a/src/include/pocketlang.h
+++ b/src/include/pocketlang.h
@@ -426,6 +426,10 @@ PK_PUBLIC PkHandle* pkNewMap(PKVM* vm);
 // already existed, otherwise an assertion will fail to indicate that.
 PK_PUBLIC PkHandle* pkNewModule(PKVM* vm, const char* name);
 
+// Register the module to the PKVM's modules map, once after it can be
+// imported in other modules.
+PK_PUBLIC void pkRegisterModule(PKVM* vm, PkHandle* module);
+
 // Create and return a new fiber around the function [fn].
 PK_PUBLIC PkHandle* pkNewFiber(PKVM* vm, PkHandle* fn);
 

--- a/src/pk_core.h
+++ b/src/pk_core.h
@@ -13,10 +13,6 @@
 // Initialize core language, builtin function and core libs.
 void initializeCore(PKVM* vm);
 
-// Return the core library with the [name] if exists in the core libs,
-// otherwise returns NULL.
-Module* getCoreLib(const PKVM* vm, String* name);
-
 /*****************************************************************************/
 /* OPERATORS                                                                 */
 /*****************************************************************************/


### PR DESCRIPTION
- a buffer of classes for primitive types added to PKVM, but they'll
not be initialized in this commit.

- names buffer and constant pool of a module are now merged (just like
java's constant pool).

- VM's core libraries and script modules are merged into a single
map name modules.

- creating a new module doesn't register it automatically anymore,
you need to call pkRegisterModule(...) each time.

- newModule() function refactored with a simpler interface, we're not
setting path or registering globals anymore, the caller is responsible for that.