### PR TITLE
functions and classes are runtime initialized

### DIFF
--- a/src/pk_debug.c
+++ b/src/pk_debug.c
@@ -407,10 +407,17 @@ void dumpFunctionCode(PKVM* vm, Function* func) {
       case OP_STORE_GLOBAL:
       {
         int index = READ_BYTE();
+        ASSERT_INDEX(index, (int)func->owner->global_names.count);
+        int name_index = func->owner->global_names.data[index];
+        ASSERT_INDEX(name_index, (int)func->owner->constants.count);
+
+        Var name = func->owner->constants.data[name_index];
+        ASSERT(IS_OBJ_TYPE(name, OBJ_STRING), OOPS);
+
         // Prints: %5d '%s'\n
         PRINT_INT(index);
         PRINT(" '");
-        PRINT(func->owner->name->data);
+        PRINT(((String*)AS_OBJ(name))->data);
         PRINT("'\n");
         break;
       }
@@ -465,6 +472,22 @@ void dumpFunctionCode(PKVM* vm, Function* func) {
         break;
       }
 
+      case OP_PUSH_CLASS:
+      {
+        int index = READ_SHORT();
+        ASSERT_INDEX((uint32_t)index, func->owner->constants.count);
+        Var value = func->owner->constants.data[index];
+        ASSERT(IS_OBJ_TYPE(value, OBJ_CLASS), OOPS);
+
+        // Prints: %5d [val]\n
+        PRINT_INT(index);
+        PRINT(" ");
+        dumpValue(vm, value);
+        NEWLINE();
+        break;
+      }
+
+      case OP_BIND_METHOD:
       case OP_CLOSE_UPVALUE:
       case OP_POP:
         NO_ARGS();

--- a/src/pk_opcodes.h
+++ b/src/pk_opcodes.h
@@ -111,6 +111,14 @@ OPCODE(STORE_UPVALUE, 1, 0)
 // params: 2 byte index.
 OPCODE(PUSH_CLOSURE, 2, 1)
 
+// Push a class at the constant pool with the index of the two bytes argument.
+// params: 2 byte index.
+OPCODE(PUSH_CLASS, 2, 1)
+
+// At the stack top, a closure and a class should be there. Add the method to
+// the class and pop it.
+OPCODE(BIND_METHOD, 0, -1)
+
 // Close the upvalue for the local at the stack top and pop it.
 OPCODE(CLOSE_UPVALUE, 0, -1)
 


### PR DESCRIPTION
this is necessary to make classes inherit from unknown
identifiers which are resolved at the runtime

and if we were to write the byte code to a file and run it, the globals
should be initialized at the runtime since there isn't any compile
time for them (pre compiled).