### PR TITLE
runFunction() abstraction to hide fiber creation

### DIFF
--- a/cli/repl.c
+++ b/cli/repl.c
@@ -134,12 +134,9 @@ int repl(PKVM* vm, const PkCompileOptions* options) {
 
     // Compiled source would be the "main" function of the module. Run it.
     PkHandle* _main = pkModuleGetMainFunction(vm, module);
-    PkHandle* fiber = pkNewFiber(vm, _main);
-    ASSERT((_main != NULL) && (fiber != NULL), OOPS);
-
-    result = pkRunFiber(vm, fiber, 0, NULL);
+    ASSERT(_main != NULL, OOPS);
+    result = pkRunFunction(vm, _main, 0, -1, -1);
     pkReleaseHandle(vm, _main);
-    pkReleaseHandle(vm, fiber);
 
   } while (!done);
 

--- a/docs/wasm/main.c
+++ b/docs/wasm/main.c
@@ -51,10 +51,8 @@ int runSource(const char* source) {
     if (result != PK_RESULT_SUCCESS) break;
 
     PkHandle* _main = pkModuleGetMainFunction(vm, module);
-    PkHandle* fiber = pkNewFiber(vm, _main);
-    result = pkRunFiber(vm, fiber, 0, NULL);
+    result = pkRunFunction(vm, _main, 0, -1, -1);
     pkReleaseHandle(vm, _main);
-    pkReleaseHandle(vm, fiber);
 
   } while (false);
   pkReleaseHandle(vm, module);

--- a/src/include/pocketlang.h
+++ b/src/include/pocketlang.h
@@ -293,20 +293,13 @@ PK_PUBLIC PkResult pkInterpretSource(PKVM* vm,
                                      PkStringPtr path,
                                      const PkCompileOptions* options);
 
-// FIXME:
-// Remove pkNewFiber and pkRunFiber functions and add interface to run closure
-// with pkRunClosure or pkRunFunction.
-
-// Create and return a new fiber around the function [fn].
-PK_PUBLIC PkHandle* pkNewFiber(PKVM* vm, PkHandle* fn);
-
-// Runs the fiber's function with the provided arguments (param [arc] is the
-// argument count and [argv] are the values). It'll returns it's run status
-// result (success or failure) if you need the yielded or returned value use
-// the pkFiberGetReturnValue() function, and use pkFiberIsDone() function to
-// check if the fiber can be resumed with pkFiberResume() function.
-PK_PUBLIC PkResult pkRunFiber(PKVM* vm, PkHandle* fiber,
-                              int argc, PkHandle** argv);
+// Run a function with [argc] arguments and their values are stored at the VM's
+// slots starting at index [argv_slot] till the next [argc] consequent slots.
+// If [argc] is 0 [argv_slot] value will be ignored.
+// To store the return value set [ret_slot] to a valid slot index, if it's
+// negative the return value will be ignored.
+PK_PUBLIC PkResult pkRunFunction(PKVM* vm, PkHandle* fn,
+                                 int argc, int argv_slot, int ret_slot);
 
 /*****************************************************************************/
 /* NATIVE / RUNTIME FUNCTION API                                             */

--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -734,15 +734,12 @@ DEF(_fiberRun,
   ASSERT(IS_OBJ_TYPE(SELF, OBJ_FIBER), OOPS);
   Fiber* self = (Fiber*)AS_OBJ(SELF);
 
-  // Buffer of argument to call vmPrepareFiber().
-  Var* args[MAX_ARGC];
-
-  for (int i = 0; i < ARGC; i++) {
-    args[i] = &ARG(i + 1);
-  }
-
-  // Switch fiber and start execution.
-  if (vmPrepareFiber(vm, self, ARGC, args)) {
+  // Switch fiber and start execution. New fibers are marked as running in
+  // either it's stats running with vmRunFiber() or here -- inserting a
+  // fiber over a running (callee) fiber.
+  if (vmPrepareFiber(vm, self, ARGC, &ARG(1))) {
+    self->caller = vm->fiber;
+    vm->fiber = self;
     self->state = FIBER_RUNNING;
   }
 }

--- a/src/pk_value.h
+++ b/src/pk_value.h
@@ -466,9 +466,9 @@ struct Fiber {
   Upvalue* open_upvalues;
 
   // The stack base pointer of the current frame. It'll be updated before
-  // calling a native function. (`fiber->ret` === `curr_call_frame->rbp`). And
-  // also updated if the stack is reallocated (that's when it's about to get
-  // overflowed.
+  // calling a native function. (`fiber->ret` === `curr_call_frame->rbp`).
+  // Return value of the callee fiber will be passed and return value of the
+  // the function that started the fiber will also be set.
   Var* ret;
 
   // The self pointer to of the current method. It'll be updated before

--- a/src/pk_vm.c
+++ b/src/pk_vm.c
@@ -147,7 +147,7 @@ void vmCollectGarbage(PKVM* vm) {
     return false;                                  \
   } while (false)
 
-bool vmPrepareFiber(PKVM* vm, Fiber* fiber, int argc, Var** argv) {
+bool vmPrepareFiber(PKVM* vm, Fiber* fiber, int argc, Var* argv) {
   ASSERT(fiber->closure->fn->arity >= -1,
          OOPS " (Forget to initialize arity.)");
 
@@ -172,7 +172,7 @@ bool vmPrepareFiber(PKVM* vm, Fiber* fiber, int argc, Var** argv) {
   }
 
   ASSERT(fiber->stack != NULL && fiber->sp == fiber->stack + 1, OOPS);
-  ASSERT(fiber->ret + 1 == fiber->sp, OOPS);
+  ASSERT(fiber->ret == fiber->stack, OOPS);
 
   // Pass the function arguments.
 
@@ -185,13 +185,9 @@ bool vmPrepareFiber(PKVM* vm, Fiber* fiber, int argc, Var** argv) {
   // ARG1 is fiber, function arguments are ARG(2), ARG(3), ... ARG(argc).
   // And ret[0] is the return value, parameters starts at ret[1], ...
   for (int i = 0; i < argc; i++) {
-    fiber->ret[1 + i] = *argv[i]; // +1: ret[0] is return value.
+    fiber->ret[1 + i] = *(argv + i); // +1: ret[0] is return value.
   }
   fiber->sp += argc; // Parameters.
-
-  // Set the new fiber as the vm's fiber.
-  fiber->caller = vm->fiber;
-  vm->fiber = fiber;
 
   // On success return true.
   return true;
@@ -247,6 +243,26 @@ void vmYieldFiber(PKVM* vm, Var* value) {
   vm->fiber->caller = NULL;
   vm->fiber->state = FIBER_YIELDED;
   vm->fiber = caller;
+}
+
+PkResult vmRunFunction(PKVM* vm, Closure* fn, int argc, Var* argv, Var* ret) {
+  ASSERT(argc >= 0, "argc cannot be negative.");
+  ASSERT(argc == 0 || argv != NULL, "argv was NULL when argc > 0.");
+
+  Fiber* fiber = newFiber(vm, fn);
+  vmPushTempRef(vm, &fiber->_super); // fiber.
+  vmPrepareFiber(vm, fiber, argc, argv);
+  vmPopTempRef(vm); // fiber.
+
+  Fiber* last = vm->fiber;
+  if (last != NULL) vmPushTempRef(vm, &last->_super); // last.
+  PkResult result = vmRunFiber(vm, fiber);
+  if (last != NULL) vmPopTempRef(vm); // last.
+  vm->fiber = last;
+
+  if (ret != NULL) *ret = *fiber->ret;
+
+  return result;
 }
 
 /*****************************************************************************/
@@ -489,8 +505,10 @@ static void reportError(PKVM* vm) {
 
 PkResult vmRunFiber(PKVM* vm, Fiber* fiber_) {
 
-  // Set the fiber as the vm's current fiber (another root object) to prevent
+  // Set the fiber as the VM's current fiber (another root object) to prevent
   // it from garbage collection and get the reference from native functions.
+  // If this is being called when running another fiber, that'll be garbage
+  // collected, if protected with vmPushTempRef() by the caller otherwise.
   vm->fiber = fiber_;
 
   ASSERT(fiber_->state == FIBER_NEW || fiber_->state == FIBER_YIELDED, OOPS);
@@ -1203,12 +1221,12 @@ L_do_call:
         // value on the stack.
         //fiber->sp = fiber->stack; ??
 
-        FIBER_SWITCH_BACK();
-
-        if (fiber == NULL) {
+        if (fiber->caller == NULL) {
+          *fiber->ret = ret_value;
           return PK_RESULT_SUCCESS;
 
         } else {
+          FIBER_SWITCH_BACK();
           *fiber->ret = ret_value;
         }
 

--- a/src/pk_vm.h
+++ b/src/pk_vm.h
@@ -204,7 +204,7 @@ Module* vmGetModule(PKVM* vm, String* key);
 // Prepare a new fiber for execution with the given arguments. That can be used
 // different fiber_run apis. Return true on success, otherwise it'll set the
 // error to the vm's current fiber (if it has any).
-bool vmPrepareFiber(PKVM* vm, Fiber* fiber, int argc, Var** argv);
+bool vmPrepareFiber(PKVM* vm, Fiber* fiber, int argc, Var* argv);
 
 // ((Context switching - resume))
 // Switch the running fiber of the vm from the current fiber to the provided
@@ -220,5 +220,10 @@ void vmYieldFiber(PKVM* vm, Var* value);
 // Runs the [fiber] if it's at yielded state, this will resume the execution
 // till the next yield or return statement, and return result.
 PkResult vmRunFiber(PKVM* vm, Fiber* fiber);
+
+// Runs the script function (if not an assertion will fail) and if the [ret] is
+// not null the return value will be set. [argv] should be the first argument
+// pointer following the rest of the arguments in an array.
+PkResult vmRunFunction(PKVM* vm, Closure* fn, int argc, Var* argv, Var* ret);
 
 #endif // PK_VM_H


### PR DESCRIPTION
the function will create a fiber and execute the function, this is
a better abstraction for the host application (createFiber, runFiber
are removed) and this will come in handy when it comes to execute
pocket functions inside a native function (it's required to
implement operator overloading along with getters and setters).