### PR TITLE
[WIP] operator overloading.

### DIFF
--- a/cli/all.c
+++ b/cli/all.c
@@ -13,6 +13,7 @@
 /* STD MODULE SOURCES                                                        */
 /*****************************************************************************/
 
+#include "modules/std_dummy.c"
 #include "modules/std_io.c"
 #include "modules/std_path.c"
 #include "modules/std_math.c"

--- a/cli/modules/modules.h
+++ b/cli/modules/modules.h
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <string.h>
 
+void registerModuleDummy(PKVM* vm);
 void registerModuleIO(PKVM* vm);
 void registerModulePath(PKVM* vm);
 void registerModuleMath(PKVM* vm);
@@ -21,6 +22,7 @@ void registerModuleMath(PKVM* vm);
 // Registers all the cli modules.
 #define REGISTER_ALL_MODULES(vm) \
   do {                           \
+    registerModuleDummy(vm);     \
     registerModuleIO(vm);        \
     registerModulePath(vm);      \
     registerModuleMath(vm);      \

--- a/cli/modules/std_dummy.c
+++ b/cli/modules/std_dummy.c
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2020-2022 Thakee Nathees
+ *  Copyright (c) 2021-2022 Pocketlang Contributors
+ *  Distributed Under The MIT License
+ */
+
+#include "modules.h"
+
+// A DUMMY MODULE TO TEST NATIVE INTERFACE AND CLASSES.
+
+typedef struct {
+  double val;
+} Dummy;
+
+void* _newDummy() {
+  Dummy* dummy = NEW_OBJ(Dummy);
+  ASSERT(dummy != NULL, "malloc failed.");
+  dummy->val = 0;
+  return dummy;
+}
+
+void _deleteDummy(void* ptr) {
+  Dummy* dummy = (Dummy*)ptr;
+  FREE_OBJ(dummy);
+}
+
+DEF(_dummyGetter, "") {
+  const char* name = pkGetSlotString(vm, 1, NULL);
+  Dummy* self = (Dummy*)pkGetSelf(vm);
+  if (strcmp("val", name) == 0) {
+    pkSetSlotNumber(vm, 0, self->val);
+    return;
+  }
+}
+
+DEF(_dummySetter, "") {
+  const char* name = pkGetSlotString(vm, 1, NULL);
+  Dummy* self = (Dummy*)pkGetSelf(vm);
+  if (strcmp("val", name) == 0) {
+    double val;
+    if (!pkValidateSlotNumber(vm, 2, &val)) return;
+    self->val = val;
+    return;
+  }
+}
+
+DEF(_dummyEq, "") {
+
+  // TODO: Currently there is no way of getting another native instance
+  // So, it's impossible to check self == other. So for now checking with
+  // number.
+  double value;
+  if (!pkValidateSlotNumber(vm, 1, &value)) return;
+
+  Dummy* self = (Dummy*)pkGetSelf(vm);
+  pkSetSlotBool(vm, 0, value == self->val);
+}
+
+DEF(_dummyGt, "") {
+
+  // TODO: Currently there is no way of getting another native instance
+  // So, it's impossible to check self == other. So for now checking with
+  // number.
+  double value;
+  if (!pkValidateSlotNumber(vm, 1, &value)) return;
+
+  Dummy* self = (Dummy*)pkGetSelf(vm);
+  pkSetSlotBool(vm, 0, self->val > value);
+}
+
+DEF(_dummyMethod,
+  "Dummy.a_method(n1:num, n2:num) -> num\n"
+  "A dummy method to check dummy method calls. Will take 2 number arguments "
+  "and return the multiplication.") {
+
+  double n1, n2;
+  if (!pkValidateSlotNumber(vm, 1, &n1)) return;
+  if (!pkValidateSlotNumber(vm, 2, &n2)) return;
+  pkSetSlotNumber(vm, 0, n1 * n2);
+
+}
+
+void registerModuleDummy(PKVM* vm) {
+  PkHandle* dummy = pkNewModule(vm, "dummy");
+
+  PkHandle* cls_dummy = pkNewClass(vm, "Dummy", NULL, dummy,
+                                   _newDummy, _deleteDummy);
+  pkClassAddMethod(vm, cls_dummy, "@getter",  _dummyGetter, 1);
+  pkClassAddMethod(vm, cls_dummy, "@setter",  _dummySetter, 2);
+  pkClassAddMethod(vm, cls_dummy, "==",       _dummyEq,     1);
+  pkClassAddMethod(vm, cls_dummy, ">",        _dummyGt,     1);
+  pkClassAddMethod(vm, cls_dummy, "a_method", _dummyMethod, 2);
+  pkReleaseHandle(vm, cls_dummy);
+
+  pkRegisterModule(vm, dummy);
+  pkReleaseHandle(vm, dummy);
+}

--- a/docs/TODO.txt
+++ b/docs/TODO.txt
@@ -1,12 +1,6 @@
 
 // Language features.
-- Closure (literal function are would become closure).
 - Utf8 support.
-- Method
-  Reference: CPython
-  See: https://github.com/python/cpython/blob/6db2db91b96aaa1270c200ec931a2250fe2799c7/Python/ceval.c#L4344-L4380
-  Note: consider dynamic attribute for instances like python and make the variables defined at the class level
-        are static.
 - Make assert a keyword and disable it on release build.
 
 // To implement.

--- a/src/pk_debug.c
+++ b/src/pk_debug.c
@@ -269,11 +269,17 @@ void dumpFunctionCode(PKVM* vm, Function* func) {
   uint32_t* lines = func->fn->oplines.data;
   uint32_t line = 1, last_line = 0;
 
+  // Either path or name should be valid to a module.
+  ASSERT(func->owner->path != NULL || func->owner->name != NULL, OOPS);
+  const char* path = (func->owner->path)
+                       ? func->owner->path->data
+                       : func->owner->name->data;
+
   // This will print: Instruction Dump of function 'fn' "path.pk"\n
   PRINT("Instruction Dump of function ");
   PRINT(func->name);
   PRINT(" ");
-  PRINT(func->owner->path->data);
+  PRINT(path);
   NEWLINE();
 
   while (i < func->fn->opcodes.count) {
@@ -588,9 +594,11 @@ void dumpFunctionCode(PKVM* vm, Function* func) {
         NO_ARGS();
         break;
 
+      case OP_POSITIVE:
       case OP_NEGATIVE:
       case OP_NOT:
       case OP_BIT_NOT:
+
       case OP_ADD:
       case OP_SUBTRACT:
       case OP_MULTIPLY:
@@ -601,6 +609,17 @@ void dumpFunctionCode(PKVM* vm, Function* func) {
       case OP_BIT_XOR:
       case OP_BIT_LSHIFT:
       case OP_BIT_RSHIFT:
+      {
+        uint8_t inplace = READ_BYTE();
+        if (inplace == 1) {
+          PRINT("(inplace)\n");
+        } else {
+          PRINT("\n");
+          ASSERT(inplace == 0, "inplace should be either 0 or 1");
+        }
+        break;
+      }
+
       case OP_EQEQ:
       case OP_NOTEQ:
       case OP_LT:

--- a/src/pk_internal.h
+++ b/src/pk_internal.h
@@ -68,20 +68,6 @@
 // The size of the error message buffer, used ar vsnprintf (since c99) buffer.
 #define ERROR_MESSAGE_SIZE 512
 
-// Functions, methods, classes and  other names which are intrenal / special to
-// pocketlang are starts with the following character (ex: @main, @literalFn).
-// When importing all (*) from a module, if the name of an entry starts with
-// this character it'll be skipped.
-#define SPECIAL_NAME_CHAR '@'
-
-// Name of the implicit function for a module. When a module is parsed all of
-// it's statements are wrapped around an implicit function with this name.
-#define IMPLICIT_MAIN_NAME "@main"
-
-// Name of a literal function. All literal function will have the same name but
-// they're uniquely identified by their index in the script's function buffer.
-#define LITERAL_FN_NAME "@func"
-
 /*****************************************************************************/
 /* ALLOCATION MACROS                                                         */
 /*****************************************************************************/

--- a/src/pk_opcodes.h
+++ b/src/pk_opcodes.h
@@ -224,22 +224,24 @@ OPCODE(GET_SUBSCRIPT_KEEP, 0, 1)
 OPCODE(SET_SUBSCRIPT, 0, -2)
 
 // Pop unary operand and push value.
+OPCODE(POSITIVE, 0, 0) //< Negative number value.
 OPCODE(NEGATIVE, 0, 0) //< Negative number value.
 OPCODE(NOT, 0, 0)      //< boolean not.
 OPCODE(BIT_NOT, 0, 0)  //< bitwise not.
 
 // Pop binary operands and push value.
-OPCODE(ADD, 0, -1)
-OPCODE(SUBTRACT, 0, -1)
-OPCODE(MULTIPLY, 0, -1)
-OPCODE(DIVIDE, 0, -1)
-OPCODE(MOD, 0, -1)
+// for parameter 1 byte is boolean inplace?.
+OPCODE(ADD, 1, -1)
+OPCODE(SUBTRACT, 1, -1)
+OPCODE(MULTIPLY, 1, -1)
+OPCODE(DIVIDE, 1, -1)
+OPCODE(MOD, 1, -1)
 
-OPCODE(BIT_AND, 0, -1)
-OPCODE(BIT_OR, 0, -1)
-OPCODE(BIT_XOR, 0, -1)
-OPCODE(BIT_LSHIFT, 0, -1)
-OPCODE(BIT_RSHIFT, 0, -1)
+OPCODE(BIT_AND, 1, -1)
+OPCODE(BIT_OR, 1, -1)
+OPCODE(BIT_XOR, 1, -1)
+OPCODE(BIT_LSHIFT, 1, -1)
+OPCODE(BIT_RSHIFT, 1, -1)
 
 OPCODE(EQEQ, 0, -1)
 OPCODE(NOTEQ, 0, -1)

--- a/src/pk_value.h
+++ b/src/pk_value.h
@@ -665,7 +665,7 @@ void listInsert(PKVM* vm, List* self, uint32_t index, Var value);
 Var listRemoveAt(PKVM* vm, List* self, uint32_t index);
 
 // Create a new list by joining the 2 given list and return the result.
-List* listJoin(PKVM* vm, List* l1, List* l2);
+List* listAdd(PKVM* vm, List* l1, List* l2);
 
 // Returns the value for the [key] in the map. If key not exists return
 // VAR_UNDEFINED.
@@ -717,16 +717,6 @@ void moduleSetGlobal(Module* module, int index, Var value);
 // false. Note that the body of the module should be NULL before calling this
 // function.
 void moduleAddMain(PKVM* vm, Module* module);
-
-// Get the attribut from the instance and set it [value]. On success return
-// true, if the attribute not exists it'll return false but won't set an error.
-bool instGetAttrib(PKVM* vm, Instance* inst, String* attrib, Var* value);
-
-// Set the attribute to the instance and return true on success, if the
-// attribute doesn't exists it'll return false but if the [value] type is
-// incompatible, this will set an error to the VM, which you can check with
-// VM_HAS_ERROR() macro function.
-bool instSetAttrib(PKVM* vm, Instance* inst, String* attrib, Var value);
 
 // Release all the object owned by the [self] including itself.
 void freeObject(PKVM* vm, Object* self);

--- a/src/pk_vm.h
+++ b/src/pk_vm.h
@@ -221,9 +221,16 @@ void vmYieldFiber(PKVM* vm, Var* value);
 // till the next yield or return statement, and return result.
 PkResult vmRunFiber(PKVM* vm, Fiber* fiber);
 
-// Runs the script function (if not an assertion will fail) and if the [ret] is
-// not null the return value will be set. [argv] should be the first argument
-// pointer following the rest of the arguments in an array.
+// Runs the function and if the [ret] is not NULL the return value will be set.
+// [argv] should be the first argument pointer following the rest of the
+// arguments in an array.
 PkResult vmRunFunction(PKVM* vm, Closure* fn, int argc, Var* argv, Var* ret);
+
+// Call the method on the [self], (witch has retrieved by the getMethod()
+// function) and if the [ret] is not NULL, the return value will be set.
+// [argv] should be the first argument pointer following the rest of the
+// arguments in an array.
+PkResult vmCallMethod(PKVM* vm, Var self, Closure* fn,
+                      int argc, Var* argv, Var* ret);
 
 #endif // PK_VM_H

--- a/tests/lang/basics.pk
+++ b/tests/lang/basics.pk
@@ -27,6 +27,11 @@ l1 = [1] + []; assert(l1.length == 1); assert(l1[0] == 1)
 l2 = l1 + [1,2,3]; assert(l2.length == 4); assert(l2 == [1,1,2,3])
 l3 = l2 + l1 + l2; assert(l3 == [1,1,2,3,1,1,1,2,3])
 
+## list references are shared.
+l1 = [1];l2 = l1;l1 += [2]
+assert(l2[1] == 2)
+assert(l1 == l2)
+
 ## in tests.
 assert(!('abc' in 'a'))
 assert(42 in [12, 42, 3.14])
@@ -35,7 +40,7 @@ assert('key' in {'key':'value'})
 assert(!('foo' in {'bar':'baz'}))
 
 ## Builtin functions tests.
-assert(to_string(42) == '42')
+assert(str(42) == '42')
 
 ## FIXME: add hash function.
 ##h1 = math.hash("testing"); h2 = math.hash("test" + "ing")
@@ -57,13 +62,13 @@ assert((a and b) == null)
 assert((b or a) == [1, 2, 3])
 assert((a or b) == b or a)
 
-## Recursive to_string list/map
+## Recursive str list/map
 l = [1]
 list_append(l, l)
-assert(to_string(l) == '[1, [...]]')
+assert(str(l) == '[1, [...]]')
 m = {}
 m['m'] = m
-assert(to_string(m) == '{"m":{...}}')
+assert(str(m) == '{"m":{...}}')
 
 # Bitwise operation tests
 assert(0b1010 | 0b0101 == 0b1111)

--- a/tests/lang/class.pk
+++ b/tests/lang/class.pk
@@ -1,49 +1,25 @@
 
-class Vec2
-  def _init(x, y)
-    self.x = x
-    self.y = y
-  end
+###############################################################################
+## Basics
+###############################################################################
 
-  def add(other)
-    return Vec2(self.x + other.x,
-                self.y + other.y)
-  end
-
-  ## Note that operator overloading / friend functions
-  ## haven't implemented at this point (to_string won't actually
-  ## override it).
-  def to_string
-    return "[${self.x}, ${self.y}]"
-  end
-
-end
-
-v1 = Vec2(1, 2); assert(v1.x == 1 and v1.y == 2)
-print("v1 = ${v1.to_string()}")
-
-v2 = Vec2(3, 4); assert(v2.x == 3 and v2.y == 4)
-print("v2 = ${v2.to_string()}")
-
-v3 = v1.add(v2); assert(v3.x == 4 and v3.y == 6)
-print("v3 = ${v3.to_string()}")
-
-
-## Default constructor crash (issue #213)
-class A
-end
-a = A()
-print(a)
-
-class B is A
-end
-
-b = B()
-assert((b is B) and (b is A))
+## TODO: write some tests here.
 
 ###############################################################################
 ## INHERITANCE
 ###############################################################################
+
+class A
+end
+
+class B is A
+end
+
+a = A()
+print(a)
+
+b = B()
+assert((b is B) and (b is A))
 
 class Shape
   def display()
@@ -95,6 +71,126 @@ assert(s is Rectangle)
 assert(s is Shape)
 assert(s.area() == 16)
 
+###############################################################################
+## OPERATOR OVERLOADING
+###############################################################################
+
+class Vec2
+  def _init(x, y)
+    self.x = x; self.y = y
+  end
+  def _str
+    return "<${self.x}, ${self.y}>"
+  end
+  def +(other)
+    return Vec2(self.x + other.x,
+                self.y + other.y)
+  end
+  def +=(other)
+    self.x += other.x
+    self.y += other.y
+    return self
+  end
+  def ==(other)
+    return self.x == other.x and self.y == other.y
+  end
+end
+
+v1 = Vec2(1, 2); assert(v1.x == 1 and v1.y == 2)
+print("v1 = $v1")
+
+assert(str(v1) == "<1, 2>")
+
+v2 = Vec2(3, 4); assert(v2.x == 3 and v2.y == 4)
+print("v2 = $v2")
+
+v3 = v1 + v2
+print("v3 = $v3")
+
+assert(v1 == Vec2(1, 2))
+
+v1 += v2
+assert(v1 == v3)
+
+class Path
+  def _init(path)
+    self.path = path
+  end
+  def /(other)
+    if other is String
+      return Path(self.path + "/" + other)
+    else if other is Path
+      return Path(self.path + "/" + other.path)
+    else
+      assert(false, "Invalid type")
+    end
+  end
+  def _str
+    return self.path
+  end
+end
+
+local = Path("/usr/local")
+pocket = Path("bin/pocket")
+print('local/pocket = "${local/pocket}"')
+assert(str(local/pocket) == "/usr/local/bin/pocket")
+assert(str(local/"lib") == "/usr/local/lib")
+
+class N
+  def _init(val)
+    self.val = val
+  end
+  def _str()
+    return "N(${self.val})"
+  end
+  def +(other)
+    return N(self.val + other.val)
+  end
+  def +=(other)
+    self.val += other.val
+    return self
+  end
+  def %=(num)
+    self.val %= num
+    return self
+  end
+  def ==(other)
+    return self.val == other.val
+  end
+  def <<(num)
+    self.val *= 10
+    self.val += num
+    return self
+  end
+  def >>(other)
+    other.val = self.val % 10
+    self.val = (self.val - other.val) / 10
+  end
+  
+  def !self()
+    self.val -= 1
+    return self.val + 1
+  end
+end
+
+n1 = N(12)
+n2 = N(23)
+assert(n1 + n2 == N(n1.val + n2.val))
+n1 %= 5
+assert(n1.val == 2)
+
+n3 = N(4) << 8 << 3 << 6
+assert(n3 == N(4836))
+
+n4 = N(0)
+n3 >> n4; assert(n4.val == 6)
+n3 >> n4; assert(n4.val == 3)
+n3 >> n4; assert(n4.val == 8)
+n3 >> n4; assert(n4.val == 4)
+
+n5 = N(3)
+assert(!n5 == 3)
+assert(!n5 == 2)
+assert(!n5 == 1)
+
 print('ALL TESTS PASSED')
-
-

--- a/tests/modules/dummy.pk
+++ b/tests/modules/dummy.pk
@@ -1,0 +1,23 @@
+
+## TODO: this dummy module is just to test different aspects of the
+## native module interface and will be removed once it become stable
+## and we have enough tests on other native interfaces.
+
+from dummy import Dummy
+
+d = Dummy()
+print(d)
+
+assert(d.val == 0) ## @getter
+d.val = 3.14       ## @setter
+assert(d.val == 3.14)
+
+assert(d == 3.14) ## == overload
+assert(d > 3)     ## > overload
+assert(d >= 3)    ## > overload
+assert(d >= 3.14) ## > and == overload
+
+assert(d.a_method(12, 34) == 408) ## method
+
+# If we got here, that means all test were passed.
+print('All TESTS PASSED')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -28,6 +28,7 @@ TEST_SUITE = {
   ),
   
   "Modules Test" : (
+    "modules/dummy.pk",
     "modules/math.pk",
   ),
 


### PR DESCRIPTION
Here is the progress so far.

```ruby
class Vec2
  def _init(x, y)
    self.x = x; self.y = y
  end

  def _str
    return "<${self.x}, ${self.y}>"
  end

  def +(other)
    return Vec2(self.x + other.x,
                self.y + other.y)
  end

  def +=(other)
    self.x += other.x
    self.y += other.y
    return self
  end

  def ==(other)
    return self.x == other.x and self.y == other.y
  end

  def -self()
    self.x = -self.x
    self.y = -self.y
    return self
  end
end

```

getters and setters for native classes implemented with the names @getter, and @setter (however the names or arity aren't validated at the moment (TODO) and won't be a part of this commit)

Note that the bellow function causes an assertion failure (maximum temp reference reached) because of the non-terminating recursion. whereas python reports a stack overflow error (not sure how to fix this).

```ruby
class A
  def _str
    return "$self" ## <-- non-terminating recursion
  end
end

a = A()
print(a) ## <-- crash
```

