### PR TITLE
scripts are moved to scritps/ directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Run check.py script.
+      - name: Run static checks.
         run: |
-          python3 tests/check.py
+          python3 scripts/static_check.py
   
   ## Compile and run test on linux.
   linux-build:
@@ -22,7 +22,7 @@ jobs:
           make all
       - name: Run tests.
         run: |
-          python3 tests/tests.py
+          python3 scripts/run_tests.py
 
   ## Compile and run tests on windows.
   windows-build:
@@ -31,10 +31,10 @@ jobs:
       - uses: actions/checkout@v2      
       - name: Run build batch script.
         run: |
-          cmd /c build.bat
+          cmd /c scripts\build.bat
       - name: Run tests.
         run: |
-          python3 tests/tests.py
+          python3 scripts/run_tests.py
 
   ## Compile and run tests on macos.
   macos-build:
@@ -46,6 +46,6 @@ jobs:
           make all
       - name: Run tests.
         run: |
-          python3 tests/tests.py
+          python3 scripts/run_tests.py
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .DS_Store
 build/
 
-tests/benchmarks/report.html
+scripts/report.html
 docs/build/
 docs/static/wasm/
 

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,15 @@ RELEASE_CFLAGS = -g -O3
 LDFLAGS        = -lm
 
 TARGET_EXEC = pocket
-BUILD_DIR   = ./build
+BUILD_DIR   = ./build/
 
-SRC_DIRS = ./src ./cli
-INC_DIRS = ./src/include
+SRC_DIRS = ./src/ ./cli/
+INC_DIRS = ./src/include/
 
-SRCS := $(foreach DIR,$(SRC_DIRS),$(wildcard $(DIR)/*.c))
+BIN_DIR = bin/
+OBJ_DIR = obj/
+
+SRCS := $(foreach DIR,$(SRC_DIRS),$(wildcard $(DIR)*.c))
 OBJS := $(SRCS:.c=.o)
 DEPS := $(OBJS:.o=.d)
 
@@ -22,13 +25,13 @@ INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 DEP_FLAGS  = -MMD -MP
 CC_FLAGS   = $(INC_FLAGS) $(DEP_FLAGS) $(CFLAGS)
 
-DEBUG_DIR     = $(BUILD_DIR)/debug
-DEBUG_TARGET  = $(DEBUG_DIR)/$(TARGET_EXEC)
-DEBUG_OBJS   := $(addprefix $(DEBUG_DIR)/, $(OBJS))
+DEBUG_DIR     = $(BUILD_DIR)Debug/
+DEBUG_TARGET  = $(DEBUG_DIR)$(BIN_DIR)$(TARGET_EXEC)
+DEBUG_OBJS   := $(addprefix $(DEBUG_DIR)$(OBJ_DIR), $(OBJS))
 
-RELEASE_DIR     = $(BUILD_DIR)/release
-RELEASE_TARGET  = $(RELEASE_DIR)/$(TARGET_EXEC)
-RELEASE_OBJS   := $(addprefix $(RELEASE_DIR)/, $(OBJS))
+RELEASE_DIR     = $(BUILD_DIR)Release/
+RELEASE_TARGET  = $(RELEASE_DIR)$(BIN_DIR)$(TARGET_EXEC)
+RELEASE_OBJS   := $(addprefix $(RELEASE_DIR)$(OBJ_DIR), $(OBJS))
 
 .PHONY: debug release all clean
 
@@ -36,18 +39,20 @@ RELEASE_OBJS   := $(addprefix $(RELEASE_DIR)/, $(OBJS))
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
+	@mkdir -p $(dir $@)
 	$(CC) $^ -o $@ $(LDFLAGS)
 
-$(DEBUG_DIR)/%.o: %.c
+$(DEBUG_DIR)$(OBJ_DIR)%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CC_FLAGS) $(DEBUG_CFLAGS) -c $< -o $@
 
 release: $(RELEASE_TARGET)
 
 $(RELEASE_TARGET): $(RELEASE_OBJS)
+	@mkdir -p $(dir $@)
 	$(CC) $^ -o $@ $(LDFLAGS)
 
-$(RELEASE_DIR)/%.o: %.c
+$(RELEASE_DIR)$(OBJ_DIR)%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CC_FLAGS) $(RELEASE_CFLAGS) -c $< -o $@
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <img src="https://user-images.githubusercontent.com/41085900/161365989-f3fd47bb-7ea7-4114-8e9b-2224e1193079.png" width="500" >
 </p>
 
-**Pocketlang** is a small (~3000 semicolons) and [fast](https://github.com/ThakeeNathees/pocketlang#performance)
-functional language written in C. It's syntactically similar to Ruby and it can
-be learned [within 15 minutes](https://thakeenathees.github.io/pocketlang/docs/v0.1.0/Reference/Cheat-Sheet.html).
+**Pocketlang** is a lightweight (~3000 semicolons) and [fast](https://github.com/ThakeeNathees/pocketlang#performance)
+object oriented, embeddable scripting language written in C. It has a ruby
+flavoured python syntax, that can be learned [within 15 minutes](https://thakeenathees.github.io/pocketlang/docs/v0.1.0/Reference/Cheat-Sheet.html).
 Including the compiler, bytecode VM and runtime, it's a standalone executable
 with zero external dependencies just as it's self descriptive name. The pocketlang
 VM can be embedded in another hosting program very easily.
@@ -85,7 +85,7 @@ from [msys2](https://www.msys2.org/) or [cygwin](https://www.cygwin.com/).
 
 #### Windows batch script
 ```
-build
+scripts\build.bat
 ```
 You don't have to run the script from a Visual Studio .NET developer command prompt, It'll search
 for the MSVS installation path and setup the build environment.
@@ -98,7 +98,10 @@ for the MSVS installation path and setup the build environment.
 4. Add `src/include` to include path.
 5. Compile.
 
-If you weren't able to compile it, please report us by [opening an issue](https://github.com/ThakeeNathees/pocketlang/issues/new).
+Visual studio project files can be generated with the premake, see
+[scripts/README](https://github.com/ThakeeNathees/pocketlang/scripts/README.md)
+for more information. If you weren't able to compile it, please report
+us by [opening an issue](https://github.com/ThakeeNathees/pocketlang/issues/new).
 
 
 ## References

--- a/cli/internal.h
+++ b/cli/internal.h
@@ -30,7 +30,7 @@
 
 #define CLI_NOTICE                                                            \
   "PocketLang " PK_VERSION_STRING " (https://github.com/ThakeeNathees/pocketlang/)\n" \
-  "Copyright (c) 2020 - 2021 ThakeeNathees\n"                                 \
+  "Copyright (c) 2020-2021 ThakeeNathees\n"                                   \
   "Copyright (c) 2021-2022 Pocketlang Contributors\n"                         \
   "Free and open source software under the terms of the MIT license.\n"
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,41 @@
+
+This directory contains all the scripts that were used to build, test, measure
+performance etc. pocketlang. These scripts in this directory are path
+independent -- can be run from anywhere.
+
+## Using premake
+
+To download the premake **which is only 1.3 MB** stand alone binary, run the
+bellow command (on windows it might be `python` and not `python3`) or you
+can download it your self at https://premake.github.io/download.
+
+```
+python3 download_premake.py
+```
+
+It will download and place the `premake.exe` (in windows) binary next to
+it, next run the following command to generate Visual studio solution files.
+
+```
+premake5 vs2019
+```
+
+for other project files and information see: https://premake.github.io/docs/
+
+## Running Benchmarks
+
+Build a release version of the pocketlang (using make file or the build.bat
+script) and run the following command to run benchmarks. It'll generate a
+benchmark report named `report.html` in this directory.
+
+```
+python3 run_benchmarks.py
+```
+
+## Other Scripts
+
+`generate_native.py` - will generate the native interface (C extension
+for pocketlang) source files from the `pocketlang.h` header. Rest of
+the scripts name speak for it self. If you want to add a build script
+or found a bug, feel free to open an issue or a PR.
+ 

--- a/scripts/download_premake.py
+++ b/scripts/download_premake.py
@@ -1,0 +1,48 @@
+##
+## Copyright (c) 2020-2022 Thakee Nathees
+## Copyright (c) 2021-2022 Pocketlang Contributors
+## Distributed Under The MIT License
+##
+
+## A tiny script to download and place premake binary in this path.
+## Primarly used to generate Visual Studio project files. Feel free
+## add other build script and platforms.
+
+import urllib.request
+import os, platform
+import tempfile, zipfile, tarfile
+from os.path import abspath, dirname, join
+
+THIS_PATH = abspath(dirname(__file__))
+
+PREMAKE_PLATFORM_URL = {
+  "Windows": "https://github.com/premake/premake-core/releases/download/v5.0.0-beta1/premake-5.0.0-beta1-windows.zip",
+  #"Linux": TODO,
+  #"Darwin": TODO,
+}
+
+def main():
+  system = platform.system()
+  if system not in PREMAKE_PLATFORM_URL:
+    error_exit(f"Platform {system} is currently not supported.\n" +\
+    "(You can modify this script to add your platform and contribute).")
+  
+  premake_url = PREMAKE_PLATFORM_URL[system]
+  tmpdir = tempfile.mkdtemp()
+  zip_path = join(tmpdir, 'premake5.zip')
+  
+  with urllib.request.urlopen(premake_url) as binary_zip:
+    with open(zip_path, 'wb') as f:
+      f.write(binary_zip.read())
+  premake_zip = zipfile.ZipFile(zip_path, 'r')
+  premake_zip.extractall(THIS_PATH)
+  
+  print("premake5 downloaded successfully.")
+
+## prints an error message to stderr and exit immediately.
+def error_exit(msg):
+  print("Error:", msg, file=sys.stderr)
+  sys.exit(1)
+
+if __name__ == "__main__":
+  main()

--- a/scripts/generate_native.py
+++ b/scripts/generate_native.py
@@ -3,6 +3,9 @@
 ## Copyright (c) 2021-2022 Pocketlang Contributors
 ## Distributed Under The MIT License
 
+raise Exception("The paths of the files should be fixed "
+      "after this script is moved to scripts/ directory.")
+
 import re, os
 from os.path import (join, exists, abspath,
                      relpath, dirname)

--- a/scripts/premake5.lua
+++ b/scripts/premake5.lua
@@ -1,0 +1,80 @@
+--
+-- Copyright (c) 2020-2022 Thakee Nathees
+-- Copyright (c) 2021-2022 Pocketlang Contributors
+-- Distributed Under The MIT License
+--
+ 
+-- Requires premake5.0.0-alpha-12 or greater.
+
+local build_dir = "../build/"
+local src_dir = "../src/"
+local cli_dir = "../cli/"
+
+workspace "pocketlang"
+  location (build_dir)
+  configurations { "Debug", "Release" }
+  platforms { "x86", "x64" }
+  filter "platforms:x86"
+    architecture "x86"
+  filter "platforms:x64"
+    architecture "x64"
+
+-- Reusable project configurations.
+function proj_commons(target_dir)
+  language "C"
+  cdialect "C99"    
+  objdir (build_dir .. "%{cfg.buildcfg}/obj/")
+  targetdir (build_dir .. "%{cfg.buildcfg}/" .. target_dir)
+  
+  filter "configurations:Debug"
+    defines { "DEBUG" }
+    symbols "On"
+  filter "configurations:Release"
+    defines { "NDEBUG" }
+    optimize "On"    
+  
+  filter "system:Windows"
+    staticruntime "On"
+    systemversion "latest"
+    postbuildcommands ""
+    defines { "_CRT_SECURE_NO_WARNINGS" }
+    
+  filter {}
+end
+
+-- pocketlang sources as static library.
+project "pocket_static"
+  kind "StaticLib"
+  targetname "pocket"
+  proj_commons("lib/")
+  files { src_dir .. "*.c",
+          src_dir .. "**.h"}
+
+-- pocketlang sources as shared library.
+project "pocket_shared"
+  kind "SharedLib"
+  targetname "pocket"
+  proj_commons("bin/")
+  files { src_dir .. "*.c",
+          src_dir .. "**.h"}
+  defines { "PK_DLL", "PK_COMPILE" }
+
+-- command line executable.
+project "pocket_cli"
+  kind "ConsoleApp"
+  targetname "pocket"
+  proj_commons("bin/")
+  files { cli_dir .. "*.c",
+          cli_dir .. "**.h" }
+  includedirs ({ src_dir .. "include/" })
+  links { "pocket_static" }
+
+  
+  
+
+
+
+
+
+
+

--- a/scripts/static_check.py
+++ b/scripts/static_check.py
@@ -10,15 +10,15 @@ import os, sys, re
 from os import listdir
 from os.path import join, abspath, dirname, relpath, normpath
 
-## The absolute path of this file, when run as a script.
-## This file is not intended to be included in other files at the moment.
-THIS_PATH = abspath(dirname(__file__))
+## Pocket lang root directory. All the listed paths bellow are relative to
+## the root path.
+ROOT_PATH = abspath(join(dirname(__file__), ".."))
 
 ## A list of source files, to check if the fnv1a hash values match it's
 ## corresponding cstring in the CASE_ATTRIB(name, hash) macro calls.
 HASH_CHECK_LIST = [
-  "../src/pk_core.c",
-  "../src/pk_value.c",
+  "src/pk_core.c",
+  "src/pk_value.c",
 ]
 
 ## A list of extension to perform static checks, of all the files in the
@@ -31,19 +31,19 @@ ALLOW_LONG_LINES = ('http://', 'https://', '<script ', '<link ', '<svg ')
 
 ## A list of files that are allowed to be longer than 79 characters.
 ALLOW_LONG_FILES = (
-  "../cli/native.py",
-  "../cli/modules/pknative.gen.c",
+  "cli/native.py",
+  "cli/modules/pknative.gen.c",
 )
 
 ## A list of directory, contains C source files to perform static checks.
 ## This will include all files with extension from CHECK_EXTENTIONS.
 SOURCE_DIRS = [
-  "../src/",
-  "../cli/",
-  "../cli/modules/",
+  "src/",
+  "cli/",
+  "cli/modules/",
 
-  "../docs/",
-  "../docs/wasm/",
+  "docs/",
+  "docs/wasm/",
 ]
 
 ## This global variable will be set to true if any check failed.
@@ -52,12 +52,12 @@ checks_failed = False
 ## Converts a list of relative paths from the working directory
 ## to a list of relative paths from this file's absolute directory.
 def to_abs_paths(sources):
-  return map(lambda s: os.path.join(THIS_PATH, s), sources)
+  return map(lambda s: os.path.join(ROOT_PATH, s), sources)
 
 ## Converts the path from absolute path to relative path from the
 ## toplelve of the project.
 def to_rel_path(path):
-  return relpath(path, join(THIS_PATH, '..'))
+  return relpath(path, ROOT_PATH)
   
 def main():
   check_fnv1_hash(to_abs_paths(HASH_CHECK_LIST))
@@ -126,7 +126,7 @@ def check_static(dirs):
               break
           for ignore in ALLOW_LONG_FILES:
             ## TODO: the bellow normpath(join()) should be calcuated once.
-            if curr_file == normpath(join(THIS_PATH, ignore)):
+            if curr_file == normpath(join(ROOT_PATH, ignore)):
               skip = True
               break
           if skip: continue


### PR DESCRIPTION
- All scripts (tests, benchmarks, build scripts) are moved to `scripts/` directory (except for makefile)
- [Premake](https://premake.github.io/) script (lua) added, which is what I used to generate MSVS solution and could be used for other project files.
- A python script `download_premake.py` added to download a premake binary (1.3 MB) and place next to it.
