### PR TITLE
super class method call implemented

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,7 +13,7 @@ can download it your self at https://premake.github.io/download.
 python3 download_premake.py
 ```
 
-It will download and place the `premake.exe` (in windows) binary next to
+It will download and place the `premake5.exe` (in windows) binary next to
 it, next run the following command to generate Visual studio solution files.
 
 ```

--- a/scripts/premake5.lua
+++ b/scripts/premake5.lua
@@ -68,13 +68,3 @@ project "pocket_cli"
           cli_dir .. "**.h" }
   includedirs ({ src_dir .. "include/" })
   links { "pocket_static" }
-
-  
-  
-
-
-
-
-
-
-

--- a/src/pk_core.h
+++ b/src/pk_core.h
@@ -75,6 +75,10 @@ Class* getClass(PKVM* vm, Var instance);
 // If the method / attribute not found, it'll set a runtime error on the VM.
 Var getMethod(PKVM* vm, Var self, String* name, bool* is_method);
 
+// Returns the method (closure) from the instance's super class. If the method
+// doesn't exists, it'll set an error on the VM.
+Closure* getSuperMethod(PKVM* vm, Var self, String* name);
+
 // Unlike getMethod this will not set error and will not try to get attribute
 // with the same name. It'll return true if the method exists on [self], false
 // otherwise and if the [method] argument is not NULL, method will be set.

--- a/src/pk_debug.c
+++ b/src/pk_debug.c
@@ -512,6 +512,7 @@ void dumpFunctionCode(PKVM* vm, Function* func) {
         break;
       }
 
+      case OP_SUPER_CALL:
       case OP_METHOD_CALL:
       {
         int argc = READ_BYTE();

--- a/src/pk_opcodes.h
+++ b/src/pk_opcodes.h
@@ -133,7 +133,14 @@ OPCODE(POP, 0, -1)
 // params: 2 byte name index.
 OPCODE(IMPORT, 2, 1)
 
-// Call a method on the variable at the stack top. See opcode CALL for detail.
+// Call a super class's method on the variable at (stack_top - argc).
+// See opcode CALL for detail.
+// params: 2 bytes method name index in the constant pool.
+//         1 byte argc.
+OPCODE(SUPER_CALL, 3, -0) //< Stack size will be calculated at compile time.
+
+// Call a method on the variable at (stack_top - argc). See opcode CALL for
+// detail.
 // params: 2 bytes method name index in the constant pool.
 //         1 byte argc.
 OPCODE(METHOD_CALL, 3, -0) //< Stack size will be calculated at compile time.

--- a/tests/lang/class.pk
+++ b/tests/lang/class.pk
@@ -193,4 +193,44 @@ assert(!n5 == 3)
 assert(!n5 == 2)
 assert(!n5 == 1)
 
+###############################################################################
+## SUPER CLASS METHOD
+###############################################################################
+
+class A
+  def _init()
+    print("A init")
+  end
+  def foo()
+    print("A foo")
+    ret = self.bar()
+    assert(ret == "B.bar")
+    return "A.foo"
+  end
+  def bar()
+    print("A bar")
+    return "A.bar"
+  end
+end
+
+class B is A
+  def _init()
+    super()
+    print("B init")
+  end  
+  def foo()
+    print("B foo")
+    ret = super()
+    assert(ret == "A.foo")
+    return super.bar()
+  end
+  def bar()
+    print("B bar")
+    return "B.bar"
+  end
+end
+
+b = B()
+assert(b.foo() == "A.bar")
+
 print('ALL TESTS PASSED')


### PR DESCRIPTION
The syntax `super(a1, a2, ...)` will call the same method in the super class or in a parent class in the inheritance tree. `super.method(a1, a2, ...)` will call a method named `method` in its super class or in a parent class in the inheritance tree.

```ruby
class A
  def _init()
    print("A init")
  end
  def foo()
    print("A foo")
    self.bar(1, 2)
  end
  def bar(x, y)
    print("A bar", x, y)
  end
end

class B is A
  def _init()
    super()
    print("B init")
  end  
  def foo()
    print("B foo")
    super()
  end
  def bar(x, y)
    print("B bar")
    super(x, y)
  end
end
```

And the output

```
A init
B init
B foo
A foo
B bar
A bar 1 2
```