### PR TITLE
stack overflow, and realloc bug fixed

### DIFF
--- a/src/pk_internal.h
+++ b/src/pk_internal.h
@@ -54,6 +54,11 @@
 // header for more information on Nan-tagging.
 #define VAR_NAN_TAGGING 1
 
+// The maximum size of the pocketlang stack. This value is arbitrary. currently
+// it's 800 KB. Change this to any value upto 2147483647 (signed integer max)
+// if you want.
+#define MAX_STACK_SIZE 1024 * 800
+
 // The maximum number of argument a pocketlang function supported to call. This
 // value is arbitrary and feel free to change it. (Just used this limit for an
 // internal buffer to store values before calling a new fiber).


### PR DESCRIPTION
Fix: #181

- stack realloc wasn't updated the next call frame's base pointer which caused a crash which is fixed
- infinite recursions are now handled properly. now it'll dump the stack frames and exit properly
- Maximum stack size is limited to 800 KB (the limit is arbitrary), in a 64 bit platform with nan-tagging enabled, at max **12800** pocketlang variables can live on the stack


```
def f()
  f()
end
f()

Error: Maximum stack limit reached.
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  ...  skipping 819178 stack frames
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  f() [test.pk:3]
  @main() [test.pk:6]
```