### PR TITLE
Memory leak detection implemented

### DIFF
--- a/scripts/leak_detect.py
+++ b/scripts/leak_detect.py
@@ -1,0 +1,75 @@
+##
+## Copyright (c) 2020-2022 Thakee Nathees
+## Copyright (c) 2021-2022 Pocketlang Contributors
+## Distributed Under The MIT License
+##
+
+## A quick script to detect memory leaks, from the trace report.
+## To get the trace report redefine TRACE_MEMORY as 1 at the
+## pk_internal.h and compile pocketlang.
+
+import sys
+
+def detect_leak():
+  trace_log_id = "[memory trace]"
+  
+  total_bytes = 0 ## Totally allocated bytes.
+  mem = dict()    ## key = address, value = bytes.
+
+  trace_log_file_path = sys.argv[1]
+
+  with open(trace_log_file_path, 'r') as f:
+    for line in f.readlines():
+      if line.startswith(trace_log_id):
+        line = line[len(trace_log_id) + 1:].strip()
+        type, data = split_and_strip(line, ':')
+        
+        addr, bytes = split_and_strip(data, '=')
+        bytes = bytes.replace(' bytes', '')
+        
+        if type == "malloc":
+          bytes = int(bytes)
+          assert(bytes >= 0); total_bytes += bytes
+          mem[addr] = bytes
+          
+        elif type == "free":
+          bytes = int(bytes)
+          assert(bytes <= 0); total_bytes += bytes
+          mem.pop(addr)
+        
+        elif type == "realloc":
+          oldp, newp = split_and_strip(addr, '->')
+          olds, news = split_and_strip(bytes, '->')
+          olds = int(olds); news = int(news)
+          total_bytes += (news - olds)
+          assert(mem[oldp] == olds)
+          mem.pop(oldp)
+          mem[newp] = news
+
+  success = True
+  if total_bytes != 0:
+    print_err(f"Memory leak detected - {total_bytes} bytes were never freed.")
+    success = False
+    
+  if len(mem) != 0:
+    print_err("Memory leak detected - some addresses were never freed.")
+    for addr in mem:
+      print(f"  {addr} : {mem[addr]} bytes")
+    success = False
+  
+  if success:
+    print("No leaks were detected.")
+  else:
+    sys.exit(1)
+
+
+def split_and_strip(string, delim):  
+  return map(lambda s: s.strip(), string.split(delim))
+
+
+def print_err(msg):
+  print("Error:", msg, file=sys.stderr)
+
+  
+if __name__ == "__main__":
+  detect_leak()

--- a/src/pk_debug.c
+++ b/src/pk_debug.c
@@ -179,7 +179,7 @@ static void _reportStackFrame(PKVM* vm, CallFrame* frame) {
   // reducing it by 1. But stack overflows are occure before executing
   // any instruction of that function, so the instruction_index possibly
   // be -1 (set it to zero in that case).
-  int instruction_index = frame->ip - fn->fn->opcodes.data - 1;
+  int instruction_index = (int) (frame->ip - fn->fn->opcodes.data) - 1;
   if (instruction_index == -1) instruction_index++;
 
   int line = fn->fn->oplines.data[instruction_index];

--- a/src/pk_internal.h
+++ b/src/pk_internal.h
@@ -50,6 +50,10 @@
 // Dump the stack values and the globals.
 #define DUMP_STACK 0
 
+// Trace memory allocations. Enable this and redirect the trace dump to a file
+// and run the script leak_detect.py to check for memory leaks.
+#define TRACE_MEMORY 0
+
 // Nan-Tagging could be disable for debugging/portability purposes. See "var.h"
 // header for more information on Nan-tagging.
 #define VAR_NAN_TAGGING 1
@@ -79,20 +83,30 @@
 
 // Allocate object of [type] using the vmRealloc function.
 #define ALLOCATE(vm, type) \
-    ((type*)vmRealloc(vm, NULL, 0, sizeof(type)))
+  ((type*)vmRealloc(vm, NULL, 0, sizeof(type)))
 
 // Allocate object of [type] which has a dynamic tail array of type [tail_type]
 // with [count] entries.
 #define ALLOCATE_DYNAMIC(vm, type, count, tail_type) \
-    ((type*)vmRealloc(vm, NULL, 0, sizeof(type) + sizeof(tail_type) * (count)))
+  ((type*)vmRealloc(vm, NULL, 0, sizeof(type) + sizeof(tail_type) * (count)))
 
 // Allocate [count] amount of object of [type] array.
 #define ALLOCATE_ARRAY(vm, type, count) \
-    ((type*)vmRealloc(vm, NULL, 0, sizeof(type) * (count)))
+  ((type*)vmRealloc(vm, NULL, 0, sizeof(type) * (count)))
 
 // Deallocate a pointer allocated by vmRealloc before.
-#define DEALLOCATE(vm, pointer) \
-    vmRealloc(vm, pointer, 0, 0)
+#define DEALLOCATE(vm, pointer, type) \
+  vmRealloc(vm, pointer, sizeof(type), 0)
+
+// Deallocate object of [type] which has a dynamic tail array of type
+// [tail_type] with [count] entries.
+#define DEALLOCATE_DYNAMIC(vm, pointer, type, count, tail_type) \
+  ((type*)vmRealloc(vm, pointer,                                \
+    sizeof(type) + sizeof(tail_type) * (count), 0))
+
+// Deallocate [count] amount of object of [type] array.
+#define DEALLOCATE_ARRAY(vm, pointer, type, count) \
+  ((type*)vmRealloc(vm, pointer, sizeof(type) * (count), 0))
 
 /*****************************************************************************/
 /* REUSABLE INTERNAL MACROS                                                  */

--- a/src/pk_public.c
+++ b/src/pk_public.c
@@ -129,7 +129,7 @@ void pkFreeVM(PKVM* vm) {
   // before freeing the VM.
   ASSERT(vm->handles == NULL, "Not all handles were released.");
 
-  DEALLOCATE(vm, vm);
+  DEALLOCATE(vm, vm, PKVM);
 }
 
 void* pkGetUserData(const PKVM* vm) {
@@ -247,7 +247,7 @@ void pkReleaseHandle(PKVM* vm, PkHandle* handle) {
   if (handle->prev) handle->prev->next = handle->next;
 
   // Free the handle.
-  DEALLOCATE(vm, handle);
+  DEALLOCATE(vm, handle, PkHandle);
 }
 
 PkResult pkCompileModule(PKVM* vm, PkHandle* module_handle, PkStringPtr source,


### PR DESCRIPTION
A little python script has written to check for memory leaks from the trace report. Which is at scripts/leak_detect.py. If any leaks, occurs, a report like below will be printed
```
> python leak_detect.py trace_dump.log
Error: Memory leak detected - 128 bytes were never freed.
Error: Memory leak detected - some addresses were never freed.
  0000027D8D8C39C0 : 32 bytes
  0000027D8D8C3F00 : 32 bytes
  0000027D8D8C4080 : 32 bytes
  0000027D8D8C3A20 : 32 bytes
```