### PR TITLE
native instance interface implemented

### DIFF
--- a/src/include/pocketlang.h
+++ b/src/include/pocketlang.h
@@ -283,8 +283,6 @@ PK_PUBLIC int pkGetArgc(const PKVM* vm);
 // that min <= max, and pocketlang won't validate this in release binary.
 PK_PUBLIC bool pkCheckArgcRange(PKVM* vm, int argc, int min, int max);
 
-// SLOTS DOCS 
-
 // Helper function to check if the argument at the [arg] slot is Boolean and
 // if not set a runtime error.
 PK_PUBLIC bool pkValidateSlotBool(PKVM* vm, int arg, bool* value);
@@ -297,6 +295,16 @@ PK_PUBLIC bool pkValidateSlotNumber(PKVM* vm, int arg, double* value);
 // if not set a runtime error.
 PK_PUBLIC bool pkValidateSlotString(PKVM* vm, int arg,
                                     const char** value, uint32_t* length);
+
+// Helper function to check if the argument at the [arg] slot is an instance
+// of the class which is at the [cls] index. If not set a runtime error.
+PK_PUBLIC bool pkValidateSlotInstanceOf(PKVM* vm, int arg, int cls);
+
+// Helper function to check if the instance at the [inst] slot is an instance
+// of the class which is at the [cls] index. The value will be set to [val]
+// if the object at [cls] slot isn't a valid class a runtime error will be set
+// and return false.
+PK_PUBLIC bool pkIsSlotInstanceOf(PKVM* vm, int inst, int cls, bool* val);
 
 // Make sure the fiber has [count] number of slots to work with (including the
 // arguments).
@@ -328,6 +336,10 @@ PK_PUBLIC const char* pkGetSlotString(PKVM* vm, int index, uint32_t* length);
 // garbage collected.
 PK_PUBLIC PkHandle* pkGetSlotHandle(PKVM* vm, int index);
 
+// Returns the native instance at the [index] slot. If the value at the [index]
+// is not a valid native instance, an assertion will fail.
+PK_PUBLIC void* pkGetSlotNativeInstance(PKVM* vm, int index);
+
 // Set the [index] slot value as pocketlang null.
 PK_PUBLIC void pkSetSlotNull(PKVM* vm, int index);
 
@@ -345,6 +357,10 @@ PK_PUBLIC void pkSetSlotString(PKVM* vm, int index, const char* value);
 PK_PUBLIC void pkSetSlotStringLength(PKVM* vm, int index,
                                      const char* value, uint32_t length);
 
+// Create a new string copying from the formated string and set it to [index]
+// slot.
+PK_PUBLIC void pkSetSlotStringFmt(PKVM* vm, int index, const char* fmt, ...);
+
 // Set the [index] slot's value as the given [handle]. The function won't
 // reclaim the ownership of the handle and you can still use it till
 // it's released by yourself.
@@ -353,6 +369,20 @@ PK_PUBLIC void pkSetSlotHandle(PKVM* vm, int index, PkHandle* handle);
 // Assign a global variable to a module at [module] slot, with the value at the
 // [global] slot with the given [name].
 PK_PUBLIC void pkSetGlobal(PKVM* vm, int module, int global, const char* name);
+
+// Creates a new instance of class at the [cls] slot, calls the constructor,
+// and place it at the [index] slot. Returns true if the instance constructed
+// successfully.
+//
+// [argc] is the argument count for the constructor, and [argv]
+// is the first argument slot's index.
+PK_PUBLIC bool pkNewInstance(PKVM* vm, int cls, int index, int argc, int argv);
+
+// Place the [self] instance at the [index] slot.
+PK_PUBLIC void pkPlaceSelf(PKVM* vm, int index);
+
+// Set the [index] slot's value as the class of the [instance].
+PK_PUBLIC void pkGetClass(PKVM* vm, int instance, int index);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/pk_value.c
+++ b/src/pk_value.c
@@ -274,6 +274,20 @@ String* newStringLength(PKVM* vm, const char* text, uint32_t length) {
   return string;
 }
 
+String* newStringCFmt(PKVM* vm, const char* fmt, va_list args) {
+  va_list copy;
+  va_copy(copy, args);
+  int size = vsnprintf(NULL, 0, fmt, copy);
+  va_end(copy);
+
+  // [size] is not including the null terminator so +1.
+  String* string = _allocateString(vm, (size_t) size + 1);
+  vsnprintf(string->data, string->capacity, fmt, args);
+  string->hash = utilHashString(string->data);
+
+  return string;
+}
+
 List* newList(PKVM* vm, uint32_t size) {
   List* list = ALLOCATE(vm, List);
   vmPushTempRef(vm, &list->_super);

--- a/src/pk_value.h
+++ b/src/pk_value.h
@@ -547,6 +547,8 @@ void varInitObject(Object* self, PKVM* vm, ObjectType type);
 
 String* newStringLength(PKVM* vm, const char* text, uint32_t length);
 
+String* newStringCFmt(PKVM* vm, const char* fmt, va_list args);
+
 // An inline function/macro implementation of newString(). Set below 0 to 1, to
 // make the implementation a static inline function, it's totally okey to
 // define a function inside a header as long as it's static (but not a fan).

--- a/src/pk_vm.c
+++ b/src/pk_vm.c
@@ -1096,6 +1096,8 @@ L_do_call:
       // citizens.
       ASSERT(!IS_OBJ_TYPE(callable, OBJ_FUNC), OOPS);
 
+      *(fiber->ret) = VAR_NULL; //< Set the return value to null.
+
       if (IS_OBJ_TYPE(callable, OBJ_CLOSURE)) {
         closure = (const Closure*)AS_OBJ(callable);
 
@@ -1105,6 +1107,12 @@ L_do_call:
         // Allocate / create a new self before calling constructor on it.
         fiber->self = preConstructSelf(vm, cls);
         CHECK_ERROR();
+
+        // Note:
+        // For pocketlang instance the constructor will update self and return
+        // the instance (which might not be necessary since we're setting it
+        // here).
+        *fiber->ret = fiber->self;
 
         closure = (const Closure*)(cls)->ctor;
         while (closure == NULL) {
@@ -1120,7 +1128,6 @@ L_do_call:
             RUNTIME_ERROR(msg);
           }
 
-          *fiber->ret = fiber->self;
           fiber->self = VAR_UNDEFINED;
           DISPATCH();
         }
@@ -1141,8 +1148,6 @@ L_do_call:
                                    buff);
         RUNTIME_ERROR(msg);
       }
-
-      *(fiber->ret) = VAR_NULL; //< Set the return value to null.
 
       if (closure->fn->is_native) {
 

--- a/tests/modules/dummy.pk
+++ b/tests/modules/dummy.pk
@@ -5,7 +5,7 @@
 
 from dummy import Dummy
 
-d = Dummy()
+d = Dummy(0)
 print(d)
 
 assert(d.val == 0) ## @getter
@@ -18,6 +18,12 @@ assert(d >= 3)    ## > overload
 assert(d >= 3.14) ## > and == overload
 
 assert(d.a_method(12, 34) == 408) ## method
+
+d1 = Dummy(12)
+d2 = Dummy(23)
+d3 = d1 + d2
+assert(d3 is Dummy)
+assert(d3.val == d1.val + d2.val)
 
 # If we got here, that means all test were passed.
 print('All TESTS PASSED')


### PR DESCRIPTION
```c
// Vec2 '+' operator method.
void _vecAdd(PKVM* vm) {
  Vector* self = (Vector*)pkGetSelf(vm);

  pkReserveSlots(vm, 5); // Now we have slots [0, 1, 2, 3, 4].

  pkPlaceSelf(vm, 2);   // slot[2] = self
  pkGetClass(vm, 2, 2); // slot[2] = Vec2 class.

  // slot[1] is slot[2] == other is Vec2 ?
  if (!pkValidateSlotInstanceOf(vm, 1, 2)) return;
  Vector* other = (Vector*) pkGetSlotNativeInstance(vm, 1);

  // slot[3] = new.x
  pkSetSlotNumber(vm, 3, self->x + other->x);

  // slot[4] = new.y
  pkSetSlotNumber(vm, 4, self->y + other->y);

  // slot[0] = Vec2(slot[3], slot[4]) => return value.
  if (!pkNewInstance(vm, 2, 0, 2, 3)) return;
}
```