### PR TITLE
native call api implemented

### DIFF
--- a/cli/modules/std_math.c
+++ b/cli/modules/std_math.c
@@ -185,9 +185,9 @@ void registerModuleMath(PKVM* vm) {
 
   // Set global value PI.
   pkReserveSlots(vm, 2);
-  pkSetSlotHandle(vm, 0, math);  // slot[0]    = math
-  pkSetSlotNumber(vm, 1, PK_PI); // slot[1]    = 3.14
-  pkSetGlobal(vm, 0, 1, "PI");   // slot[0].PI = slot[1]
+  pkSetSlotHandle(vm, 0, math);   // slot[0]    = math
+  pkSetSlotNumber(vm, 1, PK_PI);  // slot[1]    = 3.14
+  pkSetAttribute(vm, 0, 1, "PI"); // slot[0].PI = slot[1]
 
   pkModuleAddFunction(vm, math, "floor",  stdMathFloor,      1);
   pkModuleAddFunction(vm, math, "ceil",   stdMathCeil,       1);

--- a/src/pk_common.h
+++ b/src/pk_common.h
@@ -32,8 +32,9 @@
 #define __ASSERT(condition, message)                                 \
   do {                                                               \
     if (!(condition)) {                                              \
-      fprintf(stderr, "Assertion failed: %s\n\tat %s() (%s:%i)\n",   \
-        message, __func__, __FILE__, __LINE__);                      \
+      fprintf(stderr, "Assertion failed: %s\n\tat %s() (%s:%i)\n"    \
+                      "\tcondition: %s",                             \
+        message, __func__, __FILE__, __LINE__, #condition);          \
       DEBUG_BREAK();                                                 \
       abort();                                                       \
     }                                                                \

--- a/src/pk_compiler.c
+++ b/src/pk_compiler.c
@@ -2308,7 +2308,7 @@ static int compilerAddVariable(Compiler* compiler, const char* name,
   // Add the variable and return it's index.
 
   if (compiler->scope_depth == DEPTH_GLOBAL) {
-    return (int)moduleAddGlobal(compiler->parser.vm, compiler->module,
+    return (int)moduleSetGlobal(compiler->parser.vm, compiler->module,
                                 name, length, VAR_NULL);
   } else {
     Local* local = &compiler->func->locals[compiler->func->local_count];
@@ -2671,8 +2671,8 @@ static bool matchOperatorMethod(Compiler* compiler,
 // popped.
 static void compileFunction(Compiler* compiler, FuncType fn_type) {
 
-  const char* name;
-  int name_length;
+  const char* name = "(?)"; // Setting "(?)" in case of syntax errors.
+  int name_length = 3;
 
   // If it's an operator method the bellow value will set to a positive value
   // (the argc of the method) it requires to throw a compile time error.
@@ -2703,6 +2703,7 @@ static void compileFunction(Compiler* compiler, FuncType fn_type) {
   int fn_index;
   Function* func = newFunction(compiler->parser.vm, name, name_length,
                                compiler->module, false, NULL, &fn_index);
+  func->is_method = (fn_type == FUNC_METHOD || fn_type == FUNC_CONSTRUCTOR);
 
   checkMaxConstantsReached(compiler, fn_index);
 

--- a/src/pk_value.h
+++ b/src/pk_value.h
@@ -341,6 +341,10 @@ struct Function {
   // initialized.
   int arity;
 
+  // A function can be either a function or a method, and if it's a method, it
+  // cannot directly invoked without an instance.
+  bool is_method;
+
   // Number of upvalues it uses, we're defining it here (and not in object Fn)
   // is prevent checking is_native everytime (which might be a bit faster).
   int upvalue_count;
@@ -547,7 +551,7 @@ void varInitObject(Object* self, PKVM* vm, ObjectType type);
 
 String* newStringLength(PKVM* vm, const char* text, uint32_t length);
 
-String* newStringCFmt(PKVM* vm, const char* fmt, va_list args);
+String* newStringVaArgs(PKVM* vm, const char* fmt, va_list args);
 
 // An inline function/macro implementation of newString(). Set below 0 to 1, to
 // make the implementation a static inline function, it's totally okey to
@@ -702,17 +706,15 @@ String* moduleAddString(Module* module, PKVM* vm, const char* name,
 // index is negative i'll fail an assertion).
 String* moduleGetStringAt(Module* module, int index);
 
-// Add a global [value] to the [module] and return its index.
-uint32_t moduleAddGlobal(PKVM* vm, Module* module,
+// Set the global [value] to the [module] and return its index. If the global
+// [name] already exists it'll update otherwise one will be created.
+uint32_t moduleSetGlobal(PKVM* vm, Module* module,
                          const char* name, uint32_t length,
                          Var value);
 
 // Search for the [name] in the module's globals and return it's index.
 // If not found it'll return -1.
 int moduleGetGlobalIndex(Module* module, const char* name, uint32_t length);
-
-// Set the global value at [index] in the global buffer with the [value].
-void moduleSetGlobal(Module* module, int index, Var value);
 
 // This will allocate a new implicit main function for the module and assign to
 // the module's body attribute. And the attribute initialized will be set to

--- a/src/pk_vm.c
+++ b/src/pk_vm.c
@@ -323,7 +323,7 @@ PkResult vmCallMethod(PKVM* vm, Var self, Closure* fn,
   return result;
 }
 
-PkResult vmRunFunction(PKVM* vm, Closure* fn, int argc, Var* argv, Var* ret) {
+PkResult vmCallFunction(PKVM* vm, Closure* fn, int argc, Var* argv, Var* ret) {
 
   // Calling functions and methods are the same, except for the methods have
   // self defined, and for functions it'll be VAR_UNDEFINED.
@@ -1080,8 +1080,7 @@ L_vm_main_loop:
 
       index = READ_SHORT();
       name = moduleGetStringAt(module, (int)index);
-      bool is_method;
-      callable = getMethod(vm, fiber->self, name, &is_method);
+      callable = getMethod(vm, fiber->self, name, NULL);
       CHECK_ERROR();
       goto L_do_call;
 

--- a/src/pk_vm.h
+++ b/src/pk_vm.h
@@ -224,7 +224,7 @@ PkResult vmRunFiber(PKVM* vm, Fiber* fiber);
 // Runs the function and if the [ret] is not NULL the return value will be set.
 // [argv] should be the first argument pointer following the rest of the
 // arguments in an array.
-PkResult vmRunFunction(PKVM* vm, Closure* fn, int argc, Var* argv, Var* ret);
+PkResult vmCallFunction(PKVM* vm, Closure* fn, int argc, Var* argv, Var* ret);
 
 // Call the method on the [self], (witch has retrieved by the getMethod()
 // function) and if the [ret] is not NULL, the return value will be set.

--- a/tests/modules/dummy.pk
+++ b/tests/modules/dummy.pk
@@ -3,6 +3,7 @@
 ## native module interface and will be removed once it become stable
 ## and we have enough tests on other native interfaces.
 
+import dummy
 from dummy import Dummy
 
 d = Dummy(0)
@@ -24,6 +25,26 @@ d2 = Dummy(23)
 d3 = d1 + d2
 assert(d3 is Dummy)
 assert(d3.val == d1.val + d2.val)
+
+assert(dummy.afunc("foo", "bar") == "barfoo")
+
+## Test pkCallFunction()
+bar = dummy.call_native fn (a1, a2, a3)
+  print('a1 = $a1, a2 = $a2, a3 = $a3')
+  return "bar"
+end
+assert(bar == "bar")
+
+## Test pkCallMethod()
+class A
+  def do_something(a1, a2)
+    return [a2, a1]
+  end
+end
+inst = A()
+a1 = 1..2; a2 = 34
+ret = dummy.call_method(inst, 'do_something', a1, a2)
+assert(ret == [a2, a1])
 
 # If we got here, that means all test were passed.
 print('All TESTS PASSED')


### PR DESCRIPTION
### Api
```c
// Calls a function at the [fn] slot, with [argc] argument where [argv] is the
// slot of the first argument. [ret] is the slot index of the return value. if
// [ret] < 0 the return value will be discarded.
PK_PUBLIC bool pkCallFunction(PKVM* vm, int fn, int argc, int argv, int ret);

// Calls a [method] on the [instance] with [argc] argument where [argv] is the
// slot of the first argument. [ret] is the slot index of the return value. if
// [ret] < 0 the return value will be discarded.
PK_PUBLIC bool pkCallMethod(PKVM* vm, int instance, const char* method,
                            int argc, int argv, int ret);
```

### Example:

```c
void callNativeTest(PKVM* vm) {

  // slot[1] = fn
  if (!pkValidateSlotType(vm, 1, PK_CLOSURE)) return;

  pkReserveSlots(vm, 5); // Now we have slots [0, 1, 2, 3, 4].

  pkSetSlotString(vm, 2, "foo"); // slot[2] = "foo"
  pkSetSlotNumber(vm, 3, 42);    // slot[3] = 42
  pkSetSlotBool(vm, 4, false);   // slot[4] = false

  // slot[0] = slot[1](slot[2], slot[3], slot[4])
  pkCallFunction(vm, 1, 3, 2, 0);
}
```