### PR TITLE
Minor code enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ were used as a reference to write this language.
 
 ```ruby
 # Python like import statement.
-from lang import clock as now
+from time import clock as now
 
 # A recursive fibonacci function.
 def fib(n)

--- a/cli/main.c
+++ b/cli/main.c
@@ -60,7 +60,6 @@ static PKVM* intializePocketVM() {
   }
 
   PKVM* vm = pkNewVM(&config);
-  pkRegisterLibs(vm);
   return vm;
 }
 

--- a/docs/GettingStarted/LanguageManual.md
+++ b/docs/GettingStarted/LanguageManual.md
@@ -384,7 +384,7 @@ from lang import clock as now
 import foo.bar # Import module bar from foo directory
 import baz # If baz is a directory it'll import baz/_init.pk
 
-# I'll only search for foo relatievly.
+# It'll only search for foo relatievly.
 import .foo # ./foo.pk or ./foo/_init.pk or ./foo.dll, ...
 
 # ^ meaning parent directory relative to this script.

--- a/docs/wasm/compile.py
+++ b/docs/wasm/compile.py
@@ -6,7 +6,7 @@ from shutil import which
 ## This file is not intended to be included in other files at the moment.
 THIS_PATH = abspath(dirname(__file__))
 
-POCKET_SOURCE_DIR = join(THIS_PATH, "../../../pocketlang/src/")
+POCKET_ROOT = join(THIS_PATH, "../../../pocketlang/src/")
 JS_API_PATH = join(THIS_PATH, "io_api.js")
 MAIN_C = join(THIS_PATH, "main.c")
 TARGET_DIR = join(THIS_PATH, "../static/wasm/")
@@ -27,7 +27,7 @@ def main():
     os.mkdir(TARGET_DIR)
 
   sources = ' '.join(collect_source_files())
-  include = '-I' + join(POCKET_SOURCE_DIR, 'include/')
+  include = '-I' + join(POCKET_ROOT, 'include/')
   output  = join(TARGET_DIR, TARGET_NAME)
   exports = "\"EXPORTED_RUNTIME_METHODS=['ccall','cwrap']\""
   js_api  = JS_API_PATH
@@ -39,9 +39,10 @@ def main():
 
 def collect_source_files():
   sources = []
-  for file in os.listdir(POCKET_SOURCE_DIR):
-    if isdir(file): continue
-    if file.endswith('.c'): sources.append(join(POCKET_SOURCE_DIR, file))
+  for dir in ('core/', 'libs/'):
+    for file in os.listdir(join(POCKET_ROOT, dir)):
+      if isdir(file): continue
+      if file.endswith('.c'): sources.append(join(POCKET_ROOT, dir, file))
   return sources
 
 if __name__ == "__main__":

--- a/scripts/amalgamate.py
+++ b/scripts/amalgamate.py
@@ -96,10 +96,10 @@ def generate():
             '\n'
     gen += parse(header) + '\n'
 
-  gen += '#ifdef PK_IMPL\n\n'
+  gen += '#ifdef PK_IMPLEMENT\n\n'
   for source in SOURCES:
     gen += parse(source)
-  gen += '#endif // PK_IMPL\n'
+  gen += '#endif // PK_IMPLEMENT\n'
 
   return gen
   

--- a/scripts/leak_detect.py
+++ b/scripts/leak_detect.py
@@ -8,6 +8,9 @@
 ## To get the trace report redefine TRACE_MEMORY as 1 at the
 ## pk_internal.h and compile pocketlang.
 
+raise "This script Need refactor after removing pkAllocString " + \
+      "and adding pkRealloc"
+
 import sys
 
 def detect_leak():

--- a/src/core/value.c
+++ b/src/core/value.c
@@ -508,7 +508,7 @@ Instance* newInstance(PKVM* vm, Class* cls) {
   inst->attribs = newMap(vm);
 
   if (cls->new_fn != NULL) {
-    inst->native = cls->new_fn();
+    inst->native = cls->new_fn(vm);
   } else {
     inst->native = NULL;
   }
@@ -753,6 +753,8 @@ static uint32_t _hashObject(Object* obj) {
       Range* range = (Range*)obj;
       return utilHashNumber(range->from) ^ utilHashNumber(range->to);
     }
+
+    default: break;
   }
 
   UNREACHABLE();
@@ -1020,7 +1022,7 @@ void freeObject(PKVM* vm, Object* self) {
     case OBJ_INST: {
       Instance* inst = (Instance*)self;
       if (inst->cls->delete_fn != NULL) {
-        inst->cls->delete_fn(inst->native);
+        inst->cls->delete_fn(vm, inst->native);
       }
       DEALLOCATE(vm, inst, Instance);
       return;
@@ -1506,7 +1508,6 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
       }
 
       case OBJ_UPVALUE: {
-        const Upvalue* upvalue = (const Upvalue*)obj;
         pkByteBufferAddString(buff, vm, "[Upvalue]", 9);
         return;
       }

--- a/src/core/vm.h
+++ b/src/core/vm.h
@@ -235,4 +235,10 @@ PkResult vmCallFunction(PKVM* vm, Closure* fn, int argc, Var* argv, Var* ret);
 PkResult vmCallMethod(PKVM* vm, Var self, Closure* fn,
                       int argc, Var* argv, Var* ret);
 
+// Import a module with the [path] and return it. The path sepearation should
+// be '/' example: to import module "a.b" the [path] should be "a/b".
+// If the [from] is not NULL, it'll be used for relative path search.
+// On failure, it'll set an error and return VAR_NULL.
+Var vmImportModule(PKVM* vm, String* from, String* path);
+
 #endif // PK_VM_H

--- a/src/libs/libs.c
+++ b/src/libs/libs.c
@@ -8,14 +8,20 @@
 #include "libs.h"
 #endif
 
-void registerModuleDummy(PKVM* vm);
+void registerModuleMath(PKVM* vm);
+void registerModuleTime(PKVM* vm);
 void registerModuleIO(PKVM* vm);
 void registerModulePath(PKVM* vm);
-void registerModuleMath(PKVM* vm);
+void registerModuleDummy(PKVM* vm);
 
-void pkRegisterLibs(PKVM* vm) {
-  registerModuleDummy(vm);
+void registerLibs(PKVM* vm) {
+  registerModuleMath(vm);
+  registerModuleTime(vm);
   registerModuleIO(vm);
   registerModulePath(vm);
-  registerModuleMath(vm);
+  registerModuleDummy(vm);
+}
+
+void cleanupLibs(PKVM* vm) {
+
 }

--- a/src/libs/libs.h
+++ b/src/libs/libs.h
@@ -113,13 +113,6 @@
 
 #endif // PK_AMALGAMATED
 
-// Allocate a new module object of type [Ty].
-#define NEW_OBJ(Ty) (Ty*) malloc(sizeof(Ty))
-
-// Dellocate module object, allocated by NEW_OBJ(). Called by the freeObj
-// callback.
-#define FREE_OBJ(ptr) free(ptr)
-
 /*****************************************************************************/
 /* SHARED FUNCTIONS                                                          */
 /*****************************************************************************/
@@ -132,5 +125,12 @@
 // implementation is required by pockelang from it's hosting application
 // inorder to use the import statements.
 char* pathResolveImport(PKVM * vm, const char* from, const char* path);
+
+// Register all the the libraries to the PKVM.
+void registerLibs(PKVM* vm);
+
+// Cleanup registered libraries call this only if the libraries were registered
+// with registerLibs() function.
+void cleanupLibs(PKVM* vm);
 
 #endif // LIBS_H

--- a/src/libs/std_dummy.c
+++ b/src/libs/std_dummy.c
@@ -14,16 +14,15 @@ typedef struct {
   double val;
 } Dummy;
 
-void* _newDummy() {
-  Dummy* dummy = NEW_OBJ(Dummy);
-  ASSERT(dummy != NULL, "malloc failed.");
+void* _newDummy(PKVM* vm) {
+  Dummy* dummy = pkRealloc(vm, NULL, sizeof(Dummy));
+  ASSERT(dummy != NULL, "pkRealloc failed.");
   dummy->val = 0;
   return dummy;
 }
 
-void _deleteDummy(void* ptr) {
-  Dummy* dummy = (Dummy*)ptr;
-  FREE_OBJ(dummy);
+void _deleteDummy(PKVM* vm, void* ptr) {
+  pkRealloc(vm, ptr, 0);
 }
 
 DEF(_dummyInit, "") {
@@ -146,6 +145,7 @@ DEF(_dummyCallMethod,
 }
 
 void registerModuleDummy(PKVM* vm) {
+
   PkHandle* dummy = pkNewModule(vm, "dummy");
 
   pkModuleAddFunction(vm, dummy, "afunc", _dummyFunction, 2);

--- a/src/libs/std_io.c
+++ b/src/libs/std_io.c
@@ -37,21 +37,22 @@ typedef struct {
   bool closed;         // True if the file isn't closed yet.
 } File;
 
-void* _newFile() {
-  File* file = NEW_OBJ(File);
+void* _newFile(PKVM* vm) {
+  File* file = pkRealloc(vm, NULL, sizeof(File));
+  ASSERT(file != NULL, "pkRealloc failed.");
   file->closed = true;
   file->mode = FMODE_NONE;
   file->fp = NULL;
   return file;
 }
 
-void _deleteFile(void* ptr) {
+void _deleteFile(PKVM* vm, void* ptr) {
   File* file = (File*)ptr;
   if (!file->closed) {
     if (fclose(file->fp) != 0) { /* TODO: error! */ }
     file->closed = true;
   }
-  FREE_OBJ(file);
+  pkRealloc(vm, file, 0);
 }
 
 /*****************************************************************************/
@@ -123,8 +124,10 @@ DEF(_fileRead, "") {
   }
 
   // TODO: this is temporary.
+
   char buff[2048];
-  fread((void*)buff, sizeof(char), sizeof(buff), file->fp);
+  size_t read = fread((void*)buff, sizeof(char), sizeof(buff), file->fp);
+  (void) read;
   pkSetSlotString(vm, 0, (const char*)buff);
 }
 

--- a/src/libs/std_path.c
+++ b/src/libs/std_path.c
@@ -20,7 +20,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 
-#if defined(_WIN32)
+#ifdef _WIN32
   #include <windows.h>
 #endif
 
@@ -109,7 +109,7 @@ static char* tryImportPaths(PKVM* vm, char* path, char* buff) {
 
   char* ret = NULL;
   if (path_size != 0) {
-    ret = pkAllocString(vm, path_size + 1);
+    ret = pkRealloc(vm, NULL, path_size + 1);
     memcpy(ret, buff, path_size + 1);
   }
   return ret;
@@ -138,7 +138,7 @@ char* pathResolveImport(PKVM* vm, const char* from, const char* path) {
   if (cwk_path_is_absolute(path)) {
 
     // buff1 = normalized path. +1 for null terminator.
-    size_t size = cwk_path_normalize(path, buff1, sizeof(buff1)) + 1;
+    cwk_path_normalize(path, buff1, sizeof(buff1));
     pathFixWindowsSeperator(buff1);
 
     return tryImportPaths(vm, buff1, buff2);
@@ -150,7 +150,7 @@ char* pathResolveImport(PKVM* vm, const char* from, const char* path) {
     pathAbs(path, buff1, sizeof(buff1));
 
     // buff2 = normalized path. +1 for null terminator.
-    size_t size = cwk_path_normalize(buff1, buff2, sizeof(buff2)) + 1;
+    cwk_path_normalize(buff1, buff2, sizeof(buff2));
     pathFixWindowsSeperator(buff2);
 
     return tryImportPaths(vm, buff2, buff1);
@@ -173,7 +173,7 @@ char* pathResolveImport(PKVM* vm, const char* from, const char* path) {
     cwk_path_join(buff1, path, buff2, sizeof(buff2));
 
     // buff1 = normalized absolute path. +1 for null terminator
-    size_t size = cwk_path_normalize(buff2, buff1, sizeof(buff1)) + 1;
+    cwk_path_normalize(buff2, buff1, sizeof(buff1));
     pathFixWindowsSeperator(buff1);
 
     return tryImportPaths(vm, buff1, buff2);

--- a/src/libs/std_time.c
+++ b/src/libs/std_time.c
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2020-2022 Thakee Nathees
+ *  Copyright (c) 2021-2022 Pocketlang Contributors
+ *  Distributed Under The MIT License
+ */
+
+#include <time.h>
+
+#ifndef PK_AMALGAMATED
+#include "libs.h"
+#endif
+
+#ifdef _WIN32
+  #include <windows.h>
+#endif
+
+#if !defined(_MSC_VER) && !(defined(_WIN32) && defined(__TINYC__))
+  #include <unistd.h> // usleep
+#endif
+
+DEF(_timeEpoch,
+  "time() -> num\n"
+  "Returns the number of seconds since the Epoch, 1970-01-01 "
+  "00:00:00 +0000 (UTC).") {
+  pkSetSlotNumber(vm, 0, (double) time(NULL));
+}
+
+DEF(_timeClock,
+  "clock() -> num\n"
+  "Returns the number of clocks passed divied by CLOCKS_PER_SEC.") {
+  pkSetSlotNumber(vm, 0, (double) clock() / CLOCKS_PER_SEC);
+}
+
+DEF(_timeSleep,
+    "sleep(t:num) -> num\n"
+    "Sleep for [t] milliseconds.") {
+
+  double t;
+  pkValidateSlotNumber(vm, 1, &t);
+
+#if defined(_MSC_VER) || (defined(_WIN32) && defined(__TINYC__))
+  // Sleep(milli seconds)
+  Sleep((DWORD) t);
+
+#else // usleep(micro seconds)
+  usleep(((useconds_t) (t)) * 1000);
+#endif
+}
+
+void registerModuleTime(PKVM* vm) {
+  PkHandle* time = pkNewModule(vm, "time");
+
+  pkModuleAddFunction(vm, time, "epoch", _timeEpoch, 0);
+  pkModuleAddFunction(vm, time, "sleep", _timeSleep, 1);
+  pkModuleAddFunction(vm, time, "clock", _timeClock, 0);
+
+  pkRegisterModule(vm, time);
+  pkReleaseHandle(vm, time);
+}
+

--- a/tests/benchmarks/factors/factors.pk
+++ b/tests/benchmarks/factors/factors.pk
@@ -1,4 +1,4 @@
-from lang import clock
+from time import clock
 
 start = clock()
 N = 50000000; factors = []

--- a/tests/benchmarks/fib/fib.pk
+++ b/tests/benchmarks/fib/fib.pk
@@ -1,5 +1,5 @@
 
-from lang import clock
+from time import clock
 
 def fib(n)
   if n < 2 then return n end

--- a/tests/benchmarks/list/list.pk
+++ b/tests/benchmarks/list/list.pk
@@ -1,4 +1,4 @@
-from lang import clock
+from time import clock
 from math import floor
 
 def reverse_list(list)

--- a/tests/benchmarks/loop/loop.pk
+++ b/tests/benchmarks/loop/loop.pk
@@ -1,4 +1,4 @@
-from lang import clock
+from time import clock
 start = clock()
 
 l = []

--- a/tests/benchmarks/primes/primes.pk
+++ b/tests/benchmarks/primes/primes.pk
@@ -1,4 +1,4 @@
-from lang import clock
+from time import clock
 
 def is_prime(n)
   if n < 2 then return false end

--- a/tests/benchmarks/tco/tco.pk
+++ b/tests/benchmarks/tco/tco.pk
@@ -2,7 +2,7 @@
 ## Run the script in pocketlang with
 ## toc enabled VS toc disabled
 
-from lang import clock
+from time import clock
 
 N = 20000
 

--- a/tests/lang/import.pk
+++ b/tests/lang/import.pk
@@ -4,7 +4,7 @@ import lang
 import lang, path
 import lang as o, path as p
 from lang import write
-from lang import clock as c
+from time import sleep as s
 
 import basics
 import controlflow as if_test


### PR DESCRIPTION
- Libraries are registered internally when PKVM created
  and cleaned up when PKVM freed (if PK_NO_LIBS not defined)
- Lang.clock() moved to time module and sleep, epoch time
  were added.
- Support both upper case and lower case hex literals
- Support hex escaped characters inside strings (ex: "\x41")
- Native api for import modules added `pkImportModule(...)`
- pkAllocString, pkDeallocString are changed to pkRealloc.
- NewInstance, DeleteInstance functions now take PKVM however
  delete function should not allocate any memory since it's
  invoked at the GC execution.
- Some warnings were fixed