### PR TITLE
Register builtin function implementation

### DIFF
--- a/src/core/value.c
+++ b/src/core/value.c
@@ -1506,7 +1506,7 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
           for (uint32_t i = 0; i < str->length; i++) {
             char c = str->data[i];
             switch (c) {
-              case '"': pkByteBufferAddString(buff, vm, "\\\"", 2); break;
+              case '"':  pkByteBufferAddString(buff, vm, "\\\"", 2); break;
               case '\\': pkByteBufferAddString(buff, vm, "\\\\", 2); break;
               case '\n': pkByteBufferAddString(buff, vm, "\\n", 2); break;
               case '\r': pkByteBufferAddString(buff, vm, "\\r", 2); break;

--- a/src/core/vm.h
+++ b/src/core/vm.h
@@ -147,7 +147,7 @@ PkHandle* vmNewHandle(PKVM* vm, Var value);
 
 // If the stack size is less than [size], the stack will grow to keep more
 // values on it.
-void vmEnsureStackSize(PKVM* vm, int size);
+void vmEnsureStackSize(PKVM* vm, Fiber* fiber, int size);
 
 // Trigger garbage collection. This is an implementation of mark and sweep
 // garbage collection (https://en.wikipedia.org/wiki/Tracing_garbage_collection).

--- a/src/include/pocketlang.h
+++ b/src/include/pocketlang.h
@@ -212,6 +212,12 @@ PK_PUBLIC void pkSetUserData(PKVM* vm, void* user_data);
 // Returns the associated user data.
 PK_PUBLIC void* pkGetUserData(const PKVM* vm);
 
+// Register a new builtin function with the given [name]. [docstring] could be
+// NULL or will always valid pointer since PKVM doesn't allocate a string for
+// docstrings.
+PK_PUBLIC void pkRegisterBuiltinFn(PKVM* vm, const char* name, pkNativeFn fn,
+                                   int arity, const char* docstring);
+
 // Invoke pocketlang's allocator directly.  This function should be called 
 // when the host application want to send strings to the PKVM that are claimed
 // by the VM once the caller returned it. For other uses you **should** call

--- a/src/libs/std_io.c
+++ b/src/libs/std_io.c
@@ -402,11 +402,31 @@ DEF(_fileTell, "") {
   pkSetSlotNumber(vm, 0, (double) ftell(file->fp));
 }
 
+// open(path, mode='r') is equal to:
+//
+// from io import File
+// return File().open(path, mode)
+DEF(_open, NULL /* == _fileOpen */) {
+
+  // slots[1] = path
+  // slots[2] = mode
+  int argc = pkGetArgc(vm);
+  if (!pkCheckArgcRange(vm, argc, 1, 2)) return;
+  if (argc == 1) pkSetSlotString(vm, 2, "r");
+
+  if (!pkImportModule(vm, "io", 0)) return;           // slots[0] = io
+  if (!pkGetAttribute(vm, 0, "File", 0)) return;      // slots[0] = File
+  if (!pkNewInstance(vm, 0, 0, 0, 0)) return;         // slots[0] = File()
+  if (!pkCallMethod(vm, 0, "open", 2, 1, -1)) return; // slots[0] = opened file
+}
+
 /*****************************************************************************/
 /* MODULE REGISTER                                                           */
 /*****************************************************************************/
 
 void registerModuleIO(PKVM* vm) {
+
+  pkRegisterBuiltinFn(vm, "open", _open, -1, DOCSTRING(_fileOpen));
 
   PkHandle* io = pkNewModule(vm, "io");
 


### PR DESCRIPTION
Now we support registering new builtin functions via `pkRegisterBuiltinFn`, and one can extend the language for DSL
the `open` function is registered in this way, more of a syntax sugar for `from io import File; f = File(); f.open(...)`
```c
// Register a new builtin function with the given [name]. [docstring] could be
// NULL or will always valid pointer since PKVM doesn't allocate a string for
// docstrings.
PK_PUBLIC void pkRegisterBuiltinFn(PKVM* vm, const char* name, pkNativeFn fn,
                                   int arity, const char* docstring);
```