### PR TITLE
Invalid definition inside expression fixed

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -33,6 +33,7 @@ TEST_SUITE = {
   "Modules Test" : (
     "modules/dummy.pk",
     "modules/math.pk",
+    "modules/io.File.pk",
   ),
 
   "Random Scripts" : (

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -737,9 +737,9 @@ DEF(_objTypeName,
 }
 
 DEF(_objRepr,
-  "Object.repr() -> String\n"
+  "Object._repr() -> String\n"
   "Returns the repr string of the object.") {
-  RET(VAR_OBJ(varToString(vm, SELF, true)));
+  RET(VAR_OBJ(toRepr(vm, SELF)));
 }
 
 DEF(_numberTimes,
@@ -1145,7 +1145,7 @@ static void initializePrimitiveClasses(PKVM* vm) {
 
   // TODO: write docs.
   ADD_METHOD(PK_OBJECT, "typename", _objTypeName,    0);
-  ADD_METHOD(PK_OBJECT, "repr",     _objRepr,        0);
+  ADD_METHOD(PK_OBJECT, "_repr",    _objRepr,        0);
 
   ADD_METHOD(PK_NUMBER, "times",  _numberTimes,     1);
   ADD_METHOD(PK_NUMBER, "isint",  _numberIsint,     0);

--- a/src/core/debug.c
+++ b/src/core/debug.c
@@ -374,6 +374,7 @@ void dumpFunctionCode(PKVM* vm, Function* func) {
       case OP_PUSH_TRUE:
       case OP_PUSH_FALSE:
       case OP_SWAP:
+      case OP_DUP:
         NO_ARGS();
         break;
 

--- a/src/core/opcodes.h
+++ b/src/core/opcodes.h
@@ -33,6 +33,9 @@ OPCODE(PUSH_FALSE, 0, 1)
 // Swap the top 2 stack values.
 OPCODE(SWAP, 0, 0)
 
+// Duplicate the stack top value.
+OPCODE(DUP, 0, 1)
+
 // Push a new list to construct from literal.
 // param: 2 bytes list size (default is 0).
 OPCODE(PUSH_LIST, 2, 1)

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -828,6 +828,12 @@ L_vm_main_loop:
       DISPATCH();
     }
 
+    OPCODE(DUP):
+    {
+      PUSH(*(fiber->sp - 1));
+      DISPATCH();
+    }
+
     OPCODE(PUSH_LIST):
     {
       List* list = newList(vm, (uint32_t)READ_SHORT());

--- a/src/libs/std_io.c
+++ b/src/libs/std_io.c
@@ -407,6 +407,7 @@ DEF(_fileTell, "") {
 // from io import File
 // return File().open(path, mode)
 DEF(_open, NULL /* == _fileOpen */) {
+  pkReserveSlots(vm, 3);
 
   // slots[1] = path
   // slots[2] = mode

--- a/tests/lang/controlflow.pk
+++ b/tests/lang/controlflow.pk
@@ -71,5 +71,11 @@ end
 assert(val == 'bar')
 
 
+def test_in_local()
+  if x = fn y = false; return not y end ()
+    assert(x == true)
+  end
+end
+
 # If we got here, that means all test were passed.
 print('All TESTS PASSED')

--- a/tests/modules/io.File.pk
+++ b/tests/modules/io.File.pk
@@ -1,0 +1,26 @@
+
+from io import File
+from path import join, dirname
+
+FILE_PATH = join(dirname(__file__), 'test_file.txt')
+
+def read_file()
+  f = open(FILE_PATH)
+
+  assert(f is File)
+
+  LINES = [
+    'line1 : foo\n',
+    'line2 : bar\n',
+    'line3 : baz\n',
+    'line4 : qux\n',
+  ]
+
+  while line = f.getline()
+    assert(line in LINES)
+  end
+
+  f.close()
+end
+
+read_file()

--- a/tests/modules/test_file.txt
+++ b/tests/modules/test_file.txt
@@ -1,0 +1,4 @@
+line1 : foo
+line2 : bar
+line3 : baz
+line4 : qux


### PR DESCRIPTION
In the bellow code `y = 3` is assignment but `w = 4` is a definition which shouldn't be allowed inside an expression.
```ruby
x = 1; y = 2;
z = (x + 1) + (y = 3) + (w = 4)
```

```
test.pk:3 error: Variable definition isn't allowed here.
    1 |
    2 | x = 1; y = 2;
    3 | z = (x + 1) + (y = 3) + (w = 4)
      |                          ~
```