### PR TITLE
docstrings support added

### DIFF
--- a/src/core/common.h
+++ b/src/core/common.h
@@ -117,8 +117,10 @@
 
 // A macro to declare a function, with docstring, which is defined as
 // _pk_doc_<fn> = docstring; That'll used to generate function help text.
-#define DEF(fn, docstring)                      \
-  static const char* DOCSTRING(fn) = docstring; \
+// [signature] is the function name and parameter names with type information.
+// ex: `io.open(path:String, mode:String) -> io.File`
+#define DEF(fn, signature, docstring)                            \
+  static const char* DOCSTRING(fn) = signature "\n\n" docstring; \
   static void fn(PKVM* vm)
 
 #endif //PK_COMMON_H

--- a/src/core/compiler.c
+++ b/src/core/compiler.c
@@ -2630,6 +2630,14 @@ static int compileClass(Compiler* compiler) {
   emitShort(compiler, cls_index);
 
   skipNewLines(compiler);
+  if (match(compiler, TK_STRING)) {
+    Token* str = &compiler->parser.previous;
+    int index = compilerAddConstant(compiler, str->value);
+    String* docstring = moduleGetStringAt(compiler->module, index);
+    cls->docstring = docstring->data;
+  }
+
+  skipNewLines(compiler);
   while (!compiler->parser.has_syntax_error && !match(compiler, TK_END)) {
 
     if (match(compiler, TK_EOF)) {
@@ -2845,6 +2853,14 @@ static void compileFunction(Compiler* compiler, FuncType fn_type) {
 
   func->arity = argc;
   compilerChangeStack(compiler, argc);
+
+  skipNewLines(compiler);
+  if (match(compiler, TK_STRING)) {
+    Token* str = &compiler->parser.previous;
+    int index = compilerAddConstant(compiler, str->value);
+    String* docstring = moduleGetStringAt(compiler->module, index);
+    func->docstring = docstring->data;
+  }
 
   compileBlockBody(compiler, BLOCK_FUNC);
 

--- a/src/core/public.c
+++ b/src/core/public.c
@@ -245,19 +245,19 @@ void pkRegisterModule(PKVM* vm, PkHandle* module) {
 }
 
 void pkModuleAddFunction(PKVM* vm, PkHandle* module, const char* name,
-                         pkNativeFn fptr, int arity) {
+                         pkNativeFn fptr, int arity, const char* docstring) {
   CHECK_HANDLE_TYPE(module, OBJ_MODULE);
   CHECK_ARG_NULL(fptr);
 
   moduleAddFunctionInternal(vm, (Module*)AS_OBJ(module->value),
-                            name, fptr, arity,
-                            NULL /*TODO: Public API for function docstring.*/);
+                            name, fptr, arity, docstring);
 }
 
 PkHandle* pkNewClass(PKVM* vm, const char* name,
                      PkHandle* base_class, PkHandle* module,
                      pkNewInstanceFn new_fn,
-                     pkDeleteInstanceFn delete_fn) {
+                     pkDeleteInstanceFn delete_fn,
+                     const char* docstring) {
   CHECK_ARG_NULL(module);
   CHECK_ARG_NULL(name);
   CHECK_HANDLE_TYPE(module, OBJ_MODULE);
@@ -270,7 +270,7 @@ PkHandle* pkNewClass(PKVM* vm, const char* name,
 
   Class* class_ = newClass(vm, name, (int)strlen(name),
                            super, (Module*)AS_OBJ(module->value),
-                           NULL, NULL);
+                           docstring, NULL);
   class_->new_fn = new_fn;
   class_->delete_fn = delete_fn;
 
@@ -282,7 +282,7 @@ PkHandle* pkNewClass(PKVM* vm, const char* name,
 
 void pkClassAddMethod(PKVM* vm, PkHandle* cls,
                       const char* name,
-                      pkNativeFn fptr, int arity) {
+                      pkNativeFn fptr, int arity, const char* docstring) {
   CHECK_ARG_NULL(cls);
   CHECK_ARG_NULL(fptr);
   CHECK_HANDLE_TYPE(cls, OBJ_CLASS);
@@ -294,7 +294,7 @@ void pkClassAddMethod(PKVM* vm, PkHandle* cls,
   Class* class_ = (Class*)AS_OBJ(cls->value);
 
   Function* fn = newFunction(vm, name, (int)strlen(name),
-                             class_->owner, true, NULL, NULL);
+                             class_->owner, true, docstring, NULL);
   vmPushTempRef(vm, &fn->_super); // fn.
 
   fn->arity = arity;

--- a/src/core/value.c
+++ b/src/core/value.c
@@ -504,6 +504,7 @@ Class* newClass(PKVM* vm, const char* name, int length,
 
   cls->class_of = PK_INSTANCE;
   cls->super_class = super;
+  cls->docstring = docstring;
 
   // Builtin types doesn't belongs to a module.
   if (module != NULL) {

--- a/src/include/pocketlang.h
+++ b/src/include/pocketlang.h
@@ -55,6 +55,17 @@ extern "C" {
   #define PK_PUBLIC
 #endif
 
+// Returns the docstring of the function, which is a static const char* defined
+// just above the function by the DEF() macro below.
+#define PK_DOCS(fn) _pk_doc_##fn
+
+// A macro to declare a function, with docstring, which is defined as
+// _pk_doc_<fn> = docstring; That'll used to generate function help text.
+// [signature] is the function name and parameter names with type information.
+// ex: `io.open(path:String, mode:String) -> io.File`
+#define PKDEF(fn, signature, docstring)        \
+  static const char* PK_DOCS(fn) = signature "\n\n" docstring;  \
+  static void fn(PKVM* vm)
 
 /*****************************************************************************/
 /* POCKETLANG TYPEDEFS & CALLBACKS                                           */
@@ -276,22 +287,28 @@ PK_PUBLIC void pkRegisterModule(PKVM* vm, PkHandle* module);
 // Add a native function to the given module. If [arity] is -1 that means
 // the function has variadic parameters and use pkGetArgc() to get the argc.
 // Note that the function will be added as a global variable of the module.
+// [docstring] is optional and could be omitted with NULL.
 PK_PUBLIC void pkModuleAddFunction(PKVM* vm, PkHandle* module,
                                    const char* name,
-                                   pkNativeFn fptr, int arity);
+                                   pkNativeFn fptr, int arity,
+                                   const char* docstring);
 
 // Create a new class on the [module] with the [name] and return it.
 // If the [base_class] is NULL by default it'll set to "Object" class.
+// [docstring] is optional and could be omitted with NULL.
 PK_PUBLIC PkHandle* pkNewClass(PKVM* vm, const char* name,
                                PkHandle* base_class, PkHandle* module,
                                pkNewInstanceFn new_fn,
-                               pkDeleteInstanceFn delete_fn);
+                               pkDeleteInstanceFn delete_fn,
+                               const char* docstring);
 
 // Add a native method to the given class. If the [arity] is -1 that means
 // the method has variadic parameters and use pkGetArgc() to get the argc.
+// [docstring] is optional and could be omitted with NULL.
 PK_PUBLIC void pkClassAddMethod(PKVM* vm, PkHandle* cls,
                                 const char* name,
-                                pkNativeFn fptr, int arity);
+                                pkNativeFn fptr, int arity,
+                                const char* docstring);
 
 // It'll compile the pocket [source] for the module which result all the
 // functions and classes in that [source] to register on the module.

--- a/src/libs/gen/nativeapi.h
+++ b/src/libs/gen/nativeapi.h
@@ -22,9 +22,9 @@ typedef void* (*pkRealloc_t)(PKVM*, void*, size_t);
 typedef void (*pkReleaseHandle_t)(PKVM*, PkHandle*);
 typedef PkHandle* (*pkNewModule_t)(PKVM*, const char*);
 typedef void (*pkRegisterModule_t)(PKVM*, PkHandle*);
-typedef void (*pkModuleAddFunction_t)(PKVM*, PkHandle*, const char*, pkNativeFn, int);
-typedef PkHandle* (*pkNewClass_t)(PKVM*, const char*, PkHandle*, PkHandle*, pkNewInstanceFn, pkDeleteInstanceFn);
-typedef void (*pkClassAddMethod_t)(PKVM*, PkHandle*, const char*, pkNativeFn, int);
+typedef void (*pkModuleAddFunction_t)(PKVM*, PkHandle*, const char*, pkNativeFn, int, const char*);
+typedef PkHandle* (*pkNewClass_t)(PKVM*, const char*, PkHandle*, PkHandle*, pkNewInstanceFn, pkDeleteInstanceFn, const char*);
+typedef void (*pkClassAddMethod_t)(PKVM*, PkHandle*, const char*, pkNativeFn, int, const char*);
 typedef void (*pkModuleAddSource_t)(PKVM*, PkHandle*, const char*);
 typedef PkResult (*pkRunString_t)(PKVM*, const char*);
 typedef PkResult (*pkRunFile_t)(PKVM*, const char*);
@@ -131,9 +131,10 @@ typedef struct {
   pkImportModule_t pkImportModule_ptr;
 } PkNativeApi;
 
-#define PK_API_INIT_FN_NAME "pkInitApi"
-#define PK_EXPORT_FN_NAME "pkExportModule"
-#define PK_CLEANUP_FN_NAME "pkCleanupModule"
+#define PK_API_INIT_FN_NAME "pkInitApi" 
+#define PK_EXPORT_FN_NAME "pkExportModule" 
+
+#define PK_CLEANUP_FN_NAME "pkCleanupModule" 
 
 typedef void (*pkInitApiFn)(PkNativeApi*);
 typedef PkHandle* (*pkExportModuleFn)(PKVM*);

--- a/src/libs/libs.h
+++ b/src/libs/libs.h
@@ -31,6 +31,12 @@
 #define REPORT_ERRNO(fn) \
   pkSetRuntimeErrorFmt(vm, "C." #fn " errno:%i - %s.", errno, strerror(errno))
 
+#define REGISTER_FN(module, name, fn, argc) \
+  pkModuleAddFunction(vm, module, name, fn, argc, PK_DOCS(fn))
+
+#define ADD_METHOD(cls, name, fn, argc) \
+  pkClassAddMethod(vm, cls, name, fn, argc, PK_DOCS(fn));
+
 /*****************************************************************************/
 /* SHARED FUNCTIONS                                                          */
 /*****************************************************************************/

--- a/src/libs/std_dummy.c
+++ b/src/libs/std_dummy.c
@@ -25,7 +25,9 @@ void _deleteDummy(PKVM* vm, void* ptr) {
   pkRealloc(vm, ptr, 0);
 }
 
-DEF(_dummyInit, "") {
+DEF(_dummyInit,
+  "dummy.Dummy._init(n:Number)",
+  "Initialize a dummy instance with [n].") {
   double val;
   if (!pkValidateSlotNumber(vm, 1, &val)) return;
 
@@ -33,7 +35,8 @@ DEF(_dummyInit, "") {
   self->val = val;
 }
 
-DEF(_dummyGetter, "") {
+DEF(_dummyGetter, "dummy.Dummy.@getter()", "") {
+
   const char* name = pkGetSlotString(vm, 1, NULL);
   Dummy* self = (Dummy*)pkGetSelf(vm);
   if (strcmp("val", name) == 0) {
@@ -42,7 +45,7 @@ DEF(_dummyGetter, "") {
   }
 }
 
-DEF(_dummySetter, "") {
+DEF(_dummySetter, "dummy.Dummy.@setter()", "") {
   const char* name = pkGetSlotString(vm, 1, NULL);
   Dummy* self = (Dummy*)pkGetSelf(vm);
   if (strcmp("val", name) == 0) {
@@ -53,7 +56,9 @@ DEF(_dummySetter, "") {
   }
 }
 
-DEF(_dummyAdd, "") {
+DEF(_dummyAdd,
+  "dummy.Dummy.+(other:dummy.Dummy) -> dummy.Dummy",
+  "Adds two dummy instances.") {
   Dummy* self = (Dummy*) pkGetSelf(vm);
 
   pkReserveSlots(vm, 4); // Now we have slots [0, 1, 2, 3].
@@ -72,7 +77,9 @@ DEF(_dummyAdd, "") {
   if (!pkNewInstance(vm, 2, 0, 1, 3)) return;
 }
 
-DEF(_dummyEq, "") {
+DEF(_dummyEq,
+  "dummy.Dummy.==(other:dummy.Dummy) -> Bool",
+  "Check if two dummy instances are the equal.") {
 
   // TODO: Currently there is no way of getting another native instance
   // So, it's impossible to check self == other. So for now checking with
@@ -84,7 +91,9 @@ DEF(_dummyEq, "") {
   pkSetSlotBool(vm, 0, value == self->val);
 }
 
-DEF(_dummyGt, "") {
+DEF(_dummyGt,
+  "dummy.Dummy.>(other:dummy.Dummy) -> Bool",
+  "Check if the dummy instance is greater than [other].") {
 
   // TODO: Currently there is no way of getting another native instance
   // So, it's impossible to check self == other. So for now checking with
@@ -97,7 +106,7 @@ DEF(_dummyGt, "") {
 }
 
 DEF(_dummyMethod,
-  "Dummy.a_method(n1:num, n2:num) -> num\n"
+  "Dummy.a_method(n1:Number, n2:Number) -> Number",
   "A dummy method to check dummy method calls. Will take 2 number arguments "
   "and return the multiplication.") {
 
@@ -109,7 +118,7 @@ DEF(_dummyMethod,
 }
 
 DEF(_dummyFunction,
-  "dummy.afunc(s1:str, s2:str) -> str\n"
+  "dummy.afunc(s1:String, s2:String) -> String",
   "A dummy function the'll return s2 + s1.") {
 
   const char *s1, *s2;
@@ -120,8 +129,8 @@ DEF(_dummyFunction,
 }
 
 DEF(_dummyCallNative,
-  "dummy.call_native(f:fn) -> void\n"
-  "Calls the function 'f' with arguments 'foo', 42, false.") {
+  "dummy.call_native(fn:Closure) -> Null",
+  "Calls the function 'fn' with arguments 'foo', 42, false.") {
   if (!pkValidateSlotType(vm, 1, PK_CLOSURE)) return;
 
   pkReserveSlots(vm, 5); // Now we have slots [0, 1, 2, 3, 4].
@@ -134,7 +143,7 @@ DEF(_dummyCallNative,
 }
 
 DEF(_dummyCallMethod,
-  "dummy.call_method(o:Obj, method:str, a1, a2) -> \n"
+  "dummy.call_method(o:Var, method:String, a1:Var, a2:Var) -> Var",
   "Calls the method int the object [o] with two arguments [a1] and [a2].") {
   const char* method;
   if (!pkValidateSlotString(vm, 2, &method, NULL)) return;
@@ -152,19 +161,20 @@ void registerModuleDummy(PKVM* vm) {
 
   PkHandle* dummy = pkNewModule(vm, "dummy");
 
-  pkModuleAddFunction(vm, dummy, "afunc", _dummyFunction, 2);
-  pkModuleAddFunction(vm, dummy, "call_native", _dummyCallNative, 1);
-  pkModuleAddFunction(vm, dummy, "call_method", _dummyCallMethod, 4);
+  REGISTER_FN(dummy, "afunc", _dummyFunction, 2);
+  REGISTER_FN(dummy, "call_native", _dummyCallNative, 1);
+  REGISTER_FN(dummy, "call_method", _dummyCallMethod, 4);
 
   PkHandle* cls_dummy = pkNewClass(vm, "Dummy", NULL, dummy,
-                                   _newDummy, _deleteDummy);
-  pkClassAddMethod(vm, cls_dummy, "_init",    _dummyInit,   1);
-  pkClassAddMethod(vm, cls_dummy, "@getter",  _dummyGetter, 1);
-  pkClassAddMethod(vm, cls_dummy, "@setter",  _dummySetter, 2);
-  pkClassAddMethod(vm, cls_dummy, "+",        _dummyAdd,    1);
-  pkClassAddMethod(vm, cls_dummy, "==",       _dummyEq,     1);
-  pkClassAddMethod(vm, cls_dummy, ">",        _dummyGt,     1);
-  pkClassAddMethod(vm, cls_dummy, "a_method", _dummyMethod, 2);
+                                   _newDummy, _deleteDummy, NULL);
+  ADD_METHOD(cls_dummy, "_init",    _dummyInit,   1);
+  ADD_METHOD(cls_dummy, "@getter",  _dummyGetter, 1);
+  ADD_METHOD(cls_dummy, "@setter",  _dummySetter, 2);
+  ADD_METHOD(cls_dummy, "+",        _dummyAdd,    1);
+  ADD_METHOD(cls_dummy, "==",       _dummyEq,     1);
+  ADD_METHOD(cls_dummy, ">",        _dummyGt,     1);
+  ADD_METHOD(cls_dummy, "a_method", _dummyMethod, 2);
+
   pkReleaseHandle(vm, cls_dummy);
 
   pkRegisterModule(vm, dummy);

--- a/src/libs/std_json.c
+++ b/src/libs/std_json.c
@@ -160,7 +160,7 @@ static cJSON* _pocketToCJson(PKVM* vm, Var item) {
 }
 
 DEF(_jsonParse,
-  "json.parse(json_str:String) -> var\n"
+  "json.parse(json_str:String) -> Var",
   "Parse a json string into pocket lang object.") {
 
   const char* string;
@@ -186,7 +186,7 @@ DEF(_jsonParse,
 }
 
 DEF(_jsonPrint,
-  "json.print(value:Var[, pretty:Bool=false])\n"
+  "json.print(value:Var, pretty:Bool=false)",
   "Render a pocketlang value into text. Takes an optional argument pretty, if "
   "true it'll pretty print the output.") {
 
@@ -225,8 +225,8 @@ DEF(_jsonPrint,
 void registerModuleJson(PKVM* vm) {
   PkHandle* json = pkNewModule(vm, "json");
 
-  pkModuleAddFunction(vm, json, "parse", _jsonParse, 1);
-  pkModuleAddFunction(vm, json, "print", _jsonPrint, -1);
+  REGISTER_FN(json, "parse", _jsonParse, 1);
+  REGISTER_FN(json, "print", _jsonPrint, -1);
 
   pkRegisterModule(vm, json);
   pkReleaseHandle(vm, json);

--- a/src/libs/std_math.c
+++ b/src/libs/std_math.c
@@ -14,7 +14,8 @@
 #define PK_PI 3.14159265358979323846
 
 DEF(stdMathFloor,
-  "floor(value:num) -> num\n") {
+  "math.floor(value:Numberber) -> Numberber",
+  "Return the floor value.") {
 
   double num;
   if (!pkValidateSlotNumber(vm, 1, &num)) return;
@@ -22,7 +23,8 @@ DEF(stdMathFloor,
 }
 
 DEF(stdMathCeil,
-  "ceil(value:num) -> num\n") {
+  "math.ceil(value:Number) -> Number",
+  "Returns the ceiling value.") {
 
   double num;
   if (!pkValidateSlotNumber(vm, 1, &num)) return;
@@ -30,7 +32,8 @@ DEF(stdMathCeil,
 }
 
 DEF(stdMathPow,
-  "pow(a:num, b:num) -> num\n") {
+  "math.pow(a:Number, b:Number) -> Number",
+  "Returns the power 'b' of 'a' similler to a**b.") {
 
   double num, ex;
   if (!pkValidateSlotNumber(vm, 1, &num)) return;
@@ -39,7 +42,8 @@ DEF(stdMathPow,
 }
 
 DEF(stdMathSqrt,
-  "sqrt(value:num) -> num\n") {
+  "math.sqrt(value:Number) -> Number",
+  "Returns the square root of the value") {
 
   double num;
   if (!pkValidateSlotNumber(vm, 1, &num)) return;
@@ -47,7 +51,8 @@ DEF(stdMathSqrt,
 }
 
 DEF(stdMathAbs,
-  "abs(value:num) -> num\n") {
+  "math.abs(value:Number) -> Number",
+  "Returns the absolute value.") {
 
   double num;
   if (!pkValidateSlotNumber(vm, 1, &num)) return;
@@ -56,7 +61,8 @@ DEF(stdMathAbs,
 }
 
 DEF(stdMathSign,
-  "sign(value:num) -> num\n") {
+  "math.sign(value:Number) -> Number",
+  "return the sign of the which is one of (+1, 0, -1).") {
 
   double num;
   if (!pkValidateSlotNumber(vm, 1, &num)) return;
@@ -67,7 +73,7 @@ DEF(stdMathSign,
 }
 
 DEF(stdMathSine,
-  "sin(rad:num) -> num\n"
+  "math.sin(rad:Number) -> Number",
   "Return the sine value of the argument [rad] which is an angle expressed "
   "in radians.") {
 
@@ -77,7 +83,7 @@ DEF(stdMathSine,
 }
 
 DEF(stdMathCosine,
-  "cos(rad:num) -> num\n"
+  "math.cos(rad:Number) -> Number",
   "Return the cosine value of the argument [rad] which is an angle expressed "
   "in radians.") {
 
@@ -87,7 +93,7 @@ DEF(stdMathCosine,
 }
 
 DEF(stdMathTangent,
-  "tan(rad:num) -> num\n"
+  "math.tan(rad:Number) -> Number",
   "Return the tangent value of the argument [rad] which is an angle expressed "
   "in radians.") {
 
@@ -97,7 +103,7 @@ DEF(stdMathTangent,
 }
 
 DEF(stdMathSinh,
-  "sinh(val) -> val\n"
+  "math.sinh(val:Number) -> Number",
   "Return the hyperbolic sine value of the argument [val].") {
 
   double val;
@@ -106,7 +112,7 @@ DEF(stdMathSinh,
 }
 
 DEF(stdMathCosh,
-  "cosh(val) -> val\n"
+  "math.cosh(val:Number) -> Number",
   "Return the hyperbolic cosine value of the argument [val].") {
 
   double val;
@@ -115,7 +121,7 @@ DEF(stdMathCosh,
 }
 
 DEF(stdMathTanh,
-  "tanh(val) -> val\n"
+  "math.tanh(val:Number) -> Number",
   "Return the hyperbolic tangent value of the argument [val].") {
 
   double val;
@@ -124,7 +130,7 @@ DEF(stdMathTanh,
 }
 
 DEF(stdMathArcSine,
-  "asin(num) -> num\n"
+  "math.asin(num:Number) -> Number",
   "Return the arcsine value of the argument [num] which is an angle "
   "expressed in radians.") {
 
@@ -139,7 +145,7 @@ DEF(stdMathArcSine,
 }
 
 DEF(stdMathArcCosine,
-  "acos(num) -> num\n"
+  "math.acos(num:Number) -> Number",
   "Return the arc cosine value of the argument [num] which is "
   "an angle expressed in radians.") {
 
@@ -154,7 +160,7 @@ DEF(stdMathArcCosine,
 }
 
 DEF(stdMathArcTangent,
-  "atan(num) -> num\n"
+  "math.atan(num:Number) -> Number",
   "Return the arc tangent value of the argument [num] which is "
   "an angle expressed in radians.") {
 
@@ -164,7 +170,7 @@ DEF(stdMathArcTangent,
 }
 
 DEF(stdMathLog10,
-  "log10(value:num) -> num\n"
+  "math.log10(value:Number) -> Number",
   "Return the logarithm to base 10 of argument [value]") {
 
   double num;
@@ -173,7 +179,7 @@ DEF(stdMathLog10,
 }
 
 DEF(stdMathRound,
-  "round(value:num) -> num\n"
+  "math.round(value:Number) -> Number",
   "Round to nearest integer, away from zero and return the number.") {
 
   double num;
@@ -182,7 +188,7 @@ DEF(stdMathRound,
 }
 
 DEF(stdMathRand,
-  "rand() -> num\n"
+  "math.rand() -> Number",
   "Return a random runber in the range of 0..0x7fff.") {
 
   // RAND_MAX is implementation dependent but is guaranteed to be at least
@@ -205,24 +211,24 @@ void registerModuleMath(PKVM* vm) {
   pkSetSlotNumber(vm, 1, PK_PI);  // slot[1]    = 3.14
   pkSetAttribute(vm, 0, "PI", 1); // slot[0].PI = slot[1]
 
-  pkModuleAddFunction(vm, math, "floor",  stdMathFloor,      1);
-  pkModuleAddFunction(vm, math, "ceil",   stdMathCeil,       1);
-  pkModuleAddFunction(vm, math, "pow",    stdMathPow,        2);
-  pkModuleAddFunction(vm, math, "sqrt",   stdMathSqrt,       1);
-  pkModuleAddFunction(vm, math, "abs",    stdMathAbs,        1);
-  pkModuleAddFunction(vm, math, "sign",   stdMathSign,       1);
-  pkModuleAddFunction(vm, math, "sin",    stdMathSine,       1);
-  pkModuleAddFunction(vm, math, "cos",    stdMathCosine,     1);
-  pkModuleAddFunction(vm, math, "tan",    stdMathTangent,    1);
-  pkModuleAddFunction(vm, math, "sinh",   stdMathSinh,       1);
-  pkModuleAddFunction(vm, math, "cosh",   stdMathCosh,       1);
-  pkModuleAddFunction(vm, math, "tanh",   stdMathTanh,       1);
-  pkModuleAddFunction(vm, math, "asin",   stdMathArcSine,    1);
-  pkModuleAddFunction(vm, math, "acos",   stdMathArcCosine,  1);
-  pkModuleAddFunction(vm, math, "atan",   stdMathArcTangent, 1);
-  pkModuleAddFunction(vm, math, "log10",  stdMathLog10,      1);
-  pkModuleAddFunction(vm, math, "round",  stdMathRound,      1);
-  pkModuleAddFunction(vm, math, "rand",   stdMathRand,       0);
+  REGISTER_FN(math, "floor",  stdMathFloor,      1);
+  REGISTER_FN(math, "ceil",   stdMathCeil,       1);
+  REGISTER_FN(math, "pow",    stdMathPow,        2);
+  REGISTER_FN(math, "sqrt",   stdMathSqrt,       1);
+  REGISTER_FN(math, "abs",    stdMathAbs,        1);
+  REGISTER_FN(math, "sign",   stdMathSign,       1);
+  REGISTER_FN(math, "sin",    stdMathSine,       1);
+  REGISTER_FN(math, "cos",    stdMathCosine,     1);
+  REGISTER_FN(math, "tan",    stdMathTangent,    1);
+  REGISTER_FN(math, "sinh",   stdMathSinh,       1);
+  REGISTER_FN(math, "cosh",   stdMathCosh,       1);
+  REGISTER_FN(math, "tanh",   stdMathTanh,       1);
+  REGISTER_FN(math, "asin",   stdMathArcSine,    1);
+  REGISTER_FN(math, "acos",   stdMathArcCosine,  1);
+  REGISTER_FN(math, "atan",   stdMathArcTangent, 1);
+  REGISTER_FN(math, "log10",  stdMathLog10,      1);
+  REGISTER_FN(math, "round",  stdMathRound,      1);
+  REGISTER_FN(math, "rand",   stdMathRand,       0);
 
   pkRegisterModule(vm, math);
   pkReleaseHandle(vm, math);

--- a/src/libs/std_os.c
+++ b/src/libs/std_os.c
@@ -175,7 +175,7 @@ bool osGetExeFilePath(char* buff, int size) {
 
 // Yes both 'os' and 'path' have getcwd functions.
 DEF(_osGetCWD,
-  "os.getcwd() -> String\n"
+  "os.getcwd() -> String",
   "Returns the current working directory") {
   char cwd[MAX_PATH_LEN];
   if (getcwd(cwd, sizeof(cwd)) == NULL) {
@@ -185,7 +185,7 @@ DEF(_osGetCWD,
 }
 
 DEF(_osChdir,
-  "os.chdir(path:String)\n"
+  "os.chdir(path:String)",
   "Change the current working directory") {
 
   const char* path;
@@ -195,7 +195,7 @@ DEF(_osChdir,
 }
 
 DEF(_osMkdir,
-  "os.mkdir(path:String)\n"
+  "os.mkdir(path:String)",
   "Creates a directory at the path. The path should be valid.") {
 
   const char* path;
@@ -213,7 +213,7 @@ DEF(_osMkdir,
 }
 
 DEF(_osRmdir,
-  "os.rmdir(path:String)\n"
+  "os.rmdir(path:String)",
   "Removes an empty directory at the path.") {
 
   const char* path;
@@ -222,7 +222,7 @@ DEF(_osRmdir,
 }
 
 DEF(_osUnlink,
-  "os.rmdir(path:String)\n"
+  "os.rmdir(path:String)",
   "Removes a file at the path.") {
 
   const char* path;
@@ -231,7 +231,7 @@ DEF(_osUnlink,
 }
 
 DEF(_osModitime,
-  "os.moditime(path:String) -> Number\n"
+  "os.moditime(path:String) -> Number",
   "Returns the modified timestamp of the file.") {
   const char* path;
   if (!pkValidateSlotString(vm, 1, &path, NULL)) return;
@@ -243,7 +243,7 @@ DEF(_osModitime,
 }
 
 DEF(_osFileSize,
-  "os.filesize(path:String) -> Number\n"
+  "os.filesize(path:String) -> Number",
   "Returns the file size in bytes.") {
   const char* path;
 
@@ -260,7 +260,7 @@ DEF(_osFileSize,
 }
 
 DEF(_osSystem,
-  "os.system(cmd:String) -> Number\n"
+  "os.system(cmd:String) -> Number",
   "Execute the command in a subprocess, Returns the exit code of the child "
   "process.") {
   const char* cmd;
@@ -278,7 +278,7 @@ DEF(_osSystem,
 }
 
 DEF(_osGetenv,
-  "os.getenv(name:String) -> String\n"
+  "os.getenv(name:String) -> String",
   "Returns the environment variable as String if it exists otherwise it'll "
   "return null.") {
 
@@ -295,7 +295,7 @@ DEF(_osGetenv,
 }
 
 DEF(_osExepath,
-  "os.exepath() -> String\n"
+  "os.exepath() -> String",
   "Returns the path of the pocket interpreter executable.") {
 
   char buff[MAX_PATH_LEN];
@@ -320,16 +320,16 @@ void registerModuleOS(PKVM* vm) {
   pkSetSlotString(vm, 1, OS_NAME);  // slots[1] = "windows"
   pkSetAttribute(vm, 0, "NAME", 1); // os.NAME = "windows"
 
-  pkModuleAddFunction(vm, os, "getcwd", _osGetCWD, 0);
-  pkModuleAddFunction(vm, os, "chdir", _osChdir, 1);
-  pkModuleAddFunction(vm, os, "mkdir", _osMkdir, 1);
-  pkModuleAddFunction(vm, os, "rmdir", _osRmdir, 1);
-  pkModuleAddFunction(vm, os, "unlink", _osUnlink, 1);
-  pkModuleAddFunction(vm, os, "moditime", _osModitime, 1);
-  pkModuleAddFunction(vm, os, "filesize", _osFileSize, 1);
-  pkModuleAddFunction(vm, os, "system", _osSystem, 1);
-  pkModuleAddFunction(vm, os, "getenv", _osGetenv, 1);
-  pkModuleAddFunction(vm, os, "exepath", _osExepath, 0);
+  REGISTER_FN(os, "getcwd", _osGetCWD, 0);
+  REGISTER_FN(os, "chdir", _osChdir, 1);
+  REGISTER_FN(os, "mkdir", _osMkdir, 1);
+  REGISTER_FN(os, "rmdir", _osRmdir, 1);
+  REGISTER_FN(os, "unlink", _osUnlink, 1);
+  REGISTER_FN(os, "moditime", _osModitime, 1);
+  REGISTER_FN(os, "filesize", _osFileSize, 1);
+  REGISTER_FN(os, "system", _osSystem, 1);
+  REGISTER_FN(os, "getenv", _osGetenv, 1);
+  REGISTER_FN(os, "exepath", _osExepath, 0);
 
   // TODO:
   // - Implement makedirs which recursively mkdir().

--- a/src/libs/std_path.c
+++ b/src/libs/std_path.c
@@ -225,7 +225,9 @@ static inline size_t pathAbs(const char* path, char* buff, size_t buffsz) {
 /* PATH MODULE FUNCTIONS                                                     */
 /*****************************************************************************/
 
-DEF(_pathGetCWD, "") {
+DEF(_pathGetCWD,
+  "path.getcwd() -> String",
+  "Returns the current working directory.") {
   char cwd[MAX_PATH_LEN];
   if (getcwd(cwd, sizeof(cwd)) == NULL) {
     // TODO: Handle error.
@@ -233,7 +235,9 @@ DEF(_pathGetCWD, "") {
   pkSetSlotString(vm, 0, cwd);
 }
 
-DEF(_pathAbspath, "") {
+DEF(_pathAbspath,
+  "path.abspath(path:String) -> String",
+  "Returns the absolute path of the [path].") {
   const char* path;
   if (!pkValidateSlotString(vm, 1, &path, NULL)) return;
 
@@ -242,7 +246,10 @@ DEF(_pathAbspath, "") {
   pkSetSlotStringLength(vm, 0, abspath, len);
 }
 
-DEF(_pathRelpath, "") {
+DEF(_pathRelpath,
+  "path.relpath(path:String, from:String) -> String",
+  "Returns the relative path of the [path] argument from the [from] "
+  "directory.") {
   const char* path, * from;
   if (!pkValidateSlotString(vm, 1, &path, NULL)) return;
   if (!pkValidateSlotString(vm, 2, &from, NULL)) return;
@@ -259,7 +266,10 @@ DEF(_pathRelpath, "") {
   pkSetSlotStringLength(vm, 0, result, len);
 }
 
-DEF(_pathJoin, "") {
+DEF(_pathJoin,
+  "path.join(...) -> String",
+  "Joins path with path seperator and return it. The maximum count of paths "
+  "which can be joined for a call is " TOSTRING(MAX_JOIN_PATHS) ".") {
   const char* paths[MAX_JOIN_PATHS + 1]; // +1 for NULL.
   int argc = pkGetArgc(vm);
 
@@ -280,7 +290,9 @@ DEF(_pathJoin, "") {
   pkSetSlotStringLength(vm, 0, result, len);
 }
 
-DEF(_pathNormpath, "") {
+DEF(_pathNormpath,
+  "path.normpath(path:String) -> String",
+  "Returns the normalized path of the [path].") {
   const char* path;
   if (!pkValidateSlotString(vm, 1, &path, NULL)) return;
 
@@ -289,7 +301,9 @@ DEF(_pathNormpath, "") {
   pkSetSlotStringLength(vm, 0, result, len);
 }
 
-DEF(_pathBaseName, "") {
+DEF(_pathBaseName,
+  "path.basename(path:String) -> String",
+  "Returns the final component for the path") {
   const char* path;
   if (!pkValidateSlotString(vm, 1, &path, NULL)) return;
 
@@ -299,7 +313,9 @@ DEF(_pathBaseName, "") {
   pkSetSlotStringLength(vm, 0, base_name, (uint32_t)length);
 }
 
-DEF(_pathDirName, "") {
+DEF(_pathDirName,
+  "path.dirname(path:String) -> String",
+  "Returns the directory of the path.") {
   const char* path;
   if (!pkValidateSlotString(vm, 1, &path, NULL)) return;
 
@@ -308,14 +324,18 @@ DEF(_pathDirName, "") {
   pkSetSlotStringLength(vm, 0, path, (uint32_t)length);
 }
 
-DEF(_pathIsPathAbs, "") {
+DEF(_pathIsPathAbs,
+  "path.isabspath(path:String) -> Bool",
+  "Returns true if the path is absolute otherwise false.") {
   const char* path;
   if (!pkValidateSlotString(vm, 1, &path, NULL)) return;
 
   pkSetSlotBool(vm, 0, cwk_path_is_absolute(path));
 }
 
-DEF(_pathGetExtension, "") {
+DEF(_pathGetExtension,
+  "path.getext(path:String) -> String",
+  "Returns the file extension of the path.") {
   const char* path;
   if (!pkValidateSlotString(vm, 1, &path, NULL)) return;
 
@@ -328,25 +348,33 @@ DEF(_pathGetExtension, "") {
   }
 }
 
-DEF(_pathExists, "") {
+DEF(_pathExists,
+  "path.exists(path:String) -> String",
+  "Returns true if the file exists.") {
   const char* path;
   if (!pkValidateSlotString(vm, 1, &path, NULL)) return;
   pkSetSlotBool(vm, 0, pathIsExists(path));
 }
 
-DEF(_pathIsFile, "") {
+DEF(_pathIsFile,
+  "path.isfile(path:String) -> Bool",
+  "Returns true if the path is a file.") {
   const char* path;
   if (!pkValidateSlotString(vm, 1, &path, NULL)) return;
   pkSetSlotBool(vm, 0, pathIsFile(path));
 }
 
-DEF(_pathIsDir, "") {
+DEF(_pathIsDir,
+  "path.isdir(path:String) -> Bool",
+  "Returns true if the path is a directory.") {
   const char* path;
   if (!pkValidateSlotString(vm, 1, &path, NULL)) return;
   pkSetSlotBool(vm, 0, pathIsDir(path));
 }
 
-DEF(_pathListDir, "") {
+DEF(_pathListDir,
+  "path.listdir(path:String='.') -> List",
+  "Returns all the entries in the directory at the [path].") {
 
   int argc = pkGetArgc(vm);
   if (!pkCheckArgcRange(vm, argc, 0, 1)) return;
@@ -411,19 +439,19 @@ void registerModulePath(PKVM* vm) {
 
   PkHandle* path = pkNewModule(vm, "path");
 
-  pkModuleAddFunction(vm, path, "getcwd",    _pathGetCWD,       0);
-  pkModuleAddFunction(vm, path, "abspath",   _pathAbspath,      1);
-  pkModuleAddFunction(vm, path, "relpath",   _pathRelpath,      2);
-  pkModuleAddFunction(vm, path, "join",      _pathJoin,        -1);
-  pkModuleAddFunction(vm, path, "normpath",  _pathNormpath,     1);
-  pkModuleAddFunction(vm, path, "basename",  _pathBaseName,     1);
-  pkModuleAddFunction(vm, path, "dirname",   _pathDirName,      1);
-  pkModuleAddFunction(vm, path, "isabspath", _pathIsPathAbs,    1);
-  pkModuleAddFunction(vm, path, "getext",    _pathGetExtension, 1);
-  pkModuleAddFunction(vm, path, "exists",    _pathExists,       1);
-  pkModuleAddFunction(vm, path, "isfile",    _pathIsFile,       1);
-  pkModuleAddFunction(vm, path, "isdir",     _pathIsDir,        1);
-  pkModuleAddFunction(vm, path, "listdir",   _pathListDir,     -1);
+  REGISTER_FN(path, "getcwd",    _pathGetCWD,       0);
+  REGISTER_FN(path, "abspath",   _pathAbspath,      1);
+  REGISTER_FN(path, "relpath",   _pathRelpath,      2);
+  REGISTER_FN(path, "join",      _pathJoin,        -1);
+  REGISTER_FN(path, "normpath",  _pathNormpath,     1);
+  REGISTER_FN(path, "basename",  _pathBaseName,     1);
+  REGISTER_FN(path, "dirname",   _pathDirName,      1);
+  REGISTER_FN(path, "isabspath", _pathIsPathAbs,    1);
+  REGISTER_FN(path, "getext",    _pathGetExtension, 1);
+  REGISTER_FN(path, "exists",    _pathExists,       1);
+  REGISTER_FN(path, "isfile",    _pathIsFile,       1);
+  REGISTER_FN(path, "isdir",     _pathIsDir,        1);
+  REGISTER_FN(path, "listdir",   _pathListDir,     -1);
 
   pkRegisterModule(vm, path);
   pkReleaseHandle(vm, path);

--- a/src/libs/std_time.c
+++ b/src/libs/std_time.c
@@ -19,20 +19,20 @@
 #endif
 
 DEF(_timeEpoch,
-  "time() -> num\n"
+  "time() -> Number",
   "Returns the number of seconds since the Epoch, 1970-01-01 "
   "00:00:00 +0000 (UTC).") {
   pkSetSlotNumber(vm, 0, (double) time(NULL));
 }
 
 DEF(_timeClock,
-  "clock() -> num\n"
+  "clock() -> Number",
   "Returns the number of clocks passed divied by CLOCKS_PER_SEC.") {
   pkSetSlotNumber(vm, 0, (double) clock() / CLOCKS_PER_SEC);
 }
 
 DEF(_timeSleep,
-    "sleep(t:num) -> num\n"
+    "sleep(t:num) -> Number",
     "Sleep for [t] milliseconds.") {
 
   double t;
@@ -54,9 +54,9 @@ DEF(_timeSleep,
 void registerModuleTime(PKVM* vm) {
   PkHandle* time = pkNewModule(vm, "time");
 
-  pkModuleAddFunction(vm, time, "epoch", _timeEpoch, 0);
-  pkModuleAddFunction(vm, time, "sleep", _timeSleep, 1);
-  pkModuleAddFunction(vm, time, "clock", _timeClock, 0);
+  REGISTER_FN(time, "epoch", _timeEpoch, 0);
+  REGISTER_FN(time, "sleep", _timeSleep, 1);
+  REGISTER_FN(time, "clock", _timeClock, 0);
 
   pkRegisterModule(vm, time);
   pkReleaseHandle(vm, time);

--- a/tests/lang/basics.pk
+++ b/tests/lang/basics.pk
@@ -173,6 +173,17 @@ b = 'vb'; d = 'vd'; f = 'vf'
 assert("a ${ b + ' c ${d + " e ${f}"}' }" == "a vb c vd e vf")
 assert("$b$d$f" == "vbvdvf")
 
+def foo()
+  "a docstring to test"
+end
+assert(foo._docs == "a docstring to test")
+
+class Foo
+  "Testing for
+  class docstring"
+end
+assert(Foo._docs == "Testing for\n  class docstring")
+
 
 # If we got here, that means all test were passed.
 print('All TESTS PASSED')

--- a/tests/native/dl/pknative.c
+++ b/tests/native/dl/pknative.c
@@ -19,9 +19,9 @@ typedef void* (*pkRealloc_t)(PKVM*, void*, size_t);
 typedef void (*pkReleaseHandle_t)(PKVM*, PkHandle*);
 typedef PkHandle* (*pkNewModule_t)(PKVM*, const char*);
 typedef void (*pkRegisterModule_t)(PKVM*, PkHandle*);
-typedef void (*pkModuleAddFunction_t)(PKVM*, PkHandle*, const char*, pkNativeFn, int);
-typedef PkHandle* (*pkNewClass_t)(PKVM*, const char*, PkHandle*, PkHandle*, pkNewInstanceFn, pkDeleteInstanceFn);
-typedef void (*pkClassAddMethod_t)(PKVM*, PkHandle*, const char*, pkNativeFn, int);
+typedef void (*pkModuleAddFunction_t)(PKVM*, PkHandle*, const char*, pkNativeFn, int, const char*);
+typedef PkHandle* (*pkNewClass_t)(PKVM*, const char*, PkHandle*, PkHandle*, pkNewInstanceFn, pkDeleteInstanceFn, const char*);
+typedef void (*pkClassAddMethod_t)(PKVM*, PkHandle*, const char*, pkNativeFn, int, const char*);
 typedef void (*pkModuleAddSource_t)(PKVM*, PkHandle*, const char*);
 typedef PkResult (*pkRunString_t)(PKVM*, const char*);
 typedef PkResult (*pkRunFile_t)(PKVM*, const char*);
@@ -235,16 +235,16 @@ void pkRegisterModule(PKVM* vm, PkHandle* module) {
   pk_api.pkRegisterModule_ptr(vm, module);
 }
 
-void pkModuleAddFunction(PKVM* vm, PkHandle* module, const char* name, pkNativeFn fptr, int arity) {
-  pk_api.pkModuleAddFunction_ptr(vm, module, name, fptr, arity);
+void pkModuleAddFunction(PKVM* vm, PkHandle* module, const char* name, pkNativeFn fptr, int arity, const char* docstring) {
+  pk_api.pkModuleAddFunction_ptr(vm, module, name, fptr, arity, docstring);
 }
 
-PkHandle* pkNewClass(PKVM* vm, const char* name, PkHandle* base_class, PkHandle* module, pkNewInstanceFn new_fn, pkDeleteInstanceFn delete_fn) {
-  return pk_api.pkNewClass_ptr(vm, name, base_class, module, new_fn, delete_fn);
+PkHandle* pkNewClass(PKVM* vm, const char* name, PkHandle* base_class, PkHandle* module, pkNewInstanceFn new_fn, pkDeleteInstanceFn delete_fn, const char* docstring) {
+  return pk_api.pkNewClass_ptr(vm, name, base_class, module, new_fn, delete_fn, docstring);
 }
 
-void pkClassAddMethod(PKVM* vm, PkHandle* cls, const char* name, pkNativeFn fptr, int arity) {
-  pk_api.pkClassAddMethod_ptr(vm, cls, name, fptr, arity);
+void pkClassAddMethod(PKVM* vm, PkHandle* cls, const char* name, pkNativeFn fptr, int arity, const char* docstring) {
+  pk_api.pkClassAddMethod_ptr(vm, cls, name, fptr, arity, docstring);
 }
 
 void pkModuleAddSource(PKVM* vm, PkHandle* module, const char* source) {


### PR DESCRIPTION
```ruby
def foo()
  "
  pocketlang now supports, docstrings. This is similler to python's (because it's easier to parse)
  If a string literal is found before any statements inside a function it'll consumed as docstring.
  And thay will be added to the function with name `_docs` (foo._docs) will return this string.
  "
end

print(foo._docs)

```